### PR TITLE
Add network transactions to DNA summary

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -69,3 +69,4 @@
   intact while loading.
 - The DNA summary now stays hidden until Adyen data is available and is
   displayed below the Billing section in Gmail Review Mode.
+- DNA summary now includes Network Transactions from the DNA page.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -26,6 +26,7 @@ information scraped from the current page.
 - Family Tree panel shows related orders and can diagnose holds.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.
+- Network transactions from the DNA page appear in the summary.
 - A Refresh button updates information without reloading the page.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -42,3 +42,4 @@ ADDITIONAL FEATURES
 Bento Mode → Colorful grid layout with looping video background for the sidebar
 Light Mode → Minimalist black-on-white style with an inverted Fennec icon
 DNA        → Shortcut button that opens Adyen payment details and shopper DNA
+Network Transactions → Counts and amounts from the DNA page Network section

--- a/FENNEC-main 31/environments/adyen/adyen_launcher.js
+++ b/FENNEC-main 31/environments/adyen/adyen_launcher.js
@@ -134,7 +134,31 @@
                         amount: amount ? amount.textContent.trim() : ''
                     };
                 });
-                saveData({ transactions: stats, updated: Date.now() });
+
+                function extractNetworkTransactions() {
+                    const netHeading = Array.from(document.querySelectorAll('.adl-heading'))
+                        .find(h => h.textContent.trim() === 'Network');
+                    if (!netHeading || !netHeading.parentElement) return null;
+                    const txHeading = Array.from(netHeading.parentElement.querySelectorAll('.adl-heading'))
+                        .find(h => h.textContent.trim() === 'Transactions');
+                    if (!txHeading || !txHeading.parentElement) return null;
+                    const data = {};
+                    txHeading.parentElement.querySelectorAll('.item').forEach(item => {
+                        const labelEl = item.querySelector('.u-display-flex div:first-child');
+                        const amountEl = item.querySelector('.u-display-flex div:last-child');
+                        const countEl = item.querySelector('.status');
+                        if (labelEl) {
+                            data[labelEl.textContent.trim()] = {
+                                count: countEl ? countEl.textContent.trim() : '',
+                                amount: amountEl ? amountEl.textContent.trim() : ''
+                            };
+                        }
+                    });
+                    return data;
+                }
+
+                const networkTx = extractNetworkTransactions();
+                saveData({ transactions: stats, networkTransactions: networkTx, updated: Date.now() });
                 console.log('[FENNEC Adyen] DNA stats stored');
             }
 

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -679,7 +679,7 @@
         }
 
         function buildDnaHtml(info) {
-            if (!info || !info.payment || !info.transactions) return null;
+            if (!info || !info.payment) return null;
             const p = info.payment;
             const card = p.card || {};
             const shopper = p.shopper || {};
@@ -706,6 +706,12 @@
             const tx = info.transactions || {};
             Object.keys(tx).forEach(k => {
                 const t = tx[k];
+                const val = (t.count || '') + (t.amount ? ` (${t.amount})` : '');
+                add(k, val.trim());
+            });
+            const network = info.networkTransactions || {};
+            Object.keys(network).forEach(k => {
+                const t = network[k];
                 const val = (t.count || '') + (t.amount ? ` (${t.amount})` : '');
                 add(k, val.trim());
             });


### PR DESCRIPTION
## Summary
- parse Network Transactions from Adyen DNA page
- show network data in Gmail DNA summary
- document the additional details
- update glossary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599cd09c948326ada84af7b39d6d5d