### PR TITLE
Add CODA search quick action

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -29,6 +29,7 @@ information scraped from the current page.
 - Card holder name now appears in bold followed by concise card details for easier reading.
 - Network transactions from the DNA page appear in the summary.
 - A Refresh button updates information without reloading the page.
+- CODA Search menu item queries the knowledge base using the Coda API.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.
 ## Known limitations

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -43,3 +43,4 @@ Bento Mode → Colorful grid layout with looping video background for the sideba
 Light Mode → Minimalist black-on-white style with an inverted Fennec icon
 DNA        → Shortcut button that opens Adyen payment details and shopper DNA
 Network Transactions → Counts and amounts from the DNA page Network section
+CODA Search → Menu option to query the KB via the Coda API

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -524,3 +524,46 @@
     font-size: 12px;
     color: #f1f1f1;
 }
+
+#fennec-coda-overlay {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #2e2e2e;
+    color: #f1f1f1;
+    border: 1px solid gray;
+    border-radius: 8px;
+    padding: 12px 16px;
+    z-index: 1065;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    font-size: 13px;
+    text-align: center;
+}
+#fennec-coda-overlay .coda-close {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    color: #fff;
+}
+#fennec-coda-overlay input {
+    width: 260px;
+    margin: 8px 0;
+    padding: 4px;
+    border-radius: 4px;
+    border: 1px solid #555;
+}
+#fennec-coda-overlay .coda-results {
+    max-height: 240px;
+    overflow-y: auto;
+    margin-top: 8px;
+    text-align: left;
+}
+#fennec-coda-overlay .coda-result-item {
+    margin-bottom: 6px;
+}
+#fennec-coda-overlay .coda-result-item a {
+    color: #4da3ff;
+}

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -32,6 +32,19 @@
     color: #000 !important;
     border: 1px solid #777;
 }
+.fennec-light-mode #fennec-coda-overlay {
+    background: #fff;
+    color: #000 !important;
+    border: 1px solid #777;
+}
+.fennec-light-mode #fennec-coda-overlay input {
+    background: #fff;
+    color: #000;
+    border: 1px solid #777;
+}
+.fennec-light-mode #fennec-coda-overlay .coda-result-item a {
+    color: #0000ee;
+}
 .fennec-light-mode .copilot-tag {
     background-color: #000;
     color: #fff !important;


### PR DESCRIPTION
## Summary
- add CODA Search entry in the DB sidebar menu
- implement `openCodaSearch` dialog to query the Coda API
- style Coda search overlay for dark and light modes
- document new feature and glossary term

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a355a12c8326a7613a034ac85795