### PR TITLE
Fix client email/phone parsing

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -71,3 +71,4 @@
   displayed below the Billing section in Gmail Review Mode.
 - DNA summary now includes Network Transactions from the DNA page.
 - Network Transactions wait for the DNA page to fully load so details appear consistently.
+- Fixed the CLIENT summary combining email and phone when DB separates them with a <br> tag.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -33,7 +33,7 @@
     }
 
     function getText(el) {
-        return el ? (el.textContent || el.innerText || "").trim() : "";
+        return el ? (el.innerText || el.textContent || "").trim() : "";
     }
 
     function loadStoredSummary() {


### PR DESCRIPTION
## Summary
- parse `innerText` before `textContent` to keep breaks when reading contact info
- note client email/phone fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a6e5e2c083268f41dcd33d3d4c97