### PR TITLE
Fix client info email parsing

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -72,3 +72,4 @@
 - DNA summary now includes Network Transactions from the DNA page.
 - Network Transactions wait for the DNA page to fully load so details appear consistently.
 - Fixed the CLIENT summary combining email and phone when DB separates them with a <br> tag.
+- Fixed mailto links including the phone number when contact info is wrapped in a single anchor.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1937,7 +1937,10 @@
                 let phone = '';
                 if (contactCell) {
                     const mailEl = contactCell.querySelector('a[href^="mailto:"]');
-                    if (mailEl) email = getText(mailEl);
+                    if (mailEl) {
+                        const href = mailEl.getAttribute("href");
+                        email = href ? decodeURIComponent(href.replace(/^mailto:/, "")) : getText(mailEl);
+                    }
                     const text = getText(contactCell);
                     if (!email) {
                         const em = text.match(/[\w.+-]+@[\w.-]+\.[\w.-]+(?=\s|$)/);


### PR DESCRIPTION
## Summary
- fix email extraction from DB client contact info by reading the mailto link
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859aa717d7483269f16dac071373d05