### PR TITLE
Add console logs for CODA search

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -33,6 +33,8 @@ information scraped from the current page.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token. Generate
   a new token in Coda and replace the value after `Bearer` if searches return
   "No results".
+- CODA Search now logs the query and API status in the console. Look for
+  `[Copilot] CODA search` messages to confirm access.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.
 ## Known limitations

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1740,25 +1740,30 @@
         const runSearch = () => {
             const q = input.value.trim();
             if (!q) return;
-            results.textContent = 'Loading...';
-            fetch('https://coda.io/apis/v1/docs/dQJWsDF3UZ6/search?q=' + encodeURIComponent(q), {
-                headers: { 'Authorization': 'Bearer a15eec61-d7fe-4fff-9991-3a35600575b8' }
+            results.textContent = "Loading...";
+            console.log("[Copilot] CODA search query:", q);
+            fetch("https://coda.io/apis/v1/docs/dQJWsDF3UZ6/search?q=" + encodeURIComponent(q), {
+                headers: { "Authorization": "Bearer a15eec61-d7fe-4fff-9991-3a35600575b8" }
             })
-                .then(r => r.json())
+                .then(r => {
+                    console.log("[Copilot] CODA search status:", r.status);
+                    return r.json();
+                })
                 .then(data => {
+                    console.log("[Copilot] CODA search response:", data);
                     if (!data || !data.items || !data.items.length) {
-                        results.textContent = 'No results';
+                        results.textContent = "No results";
                         return;
                     }
                     results.innerHTML = data.items.map(item => {
-                        const t = item.name || item.title || '';
-                        const link = item.browserLink || item.url || '#';
+                        const t = item.name || item.title || "";
+                        const link = item.browserLink || item.url || "#";
                         return `<div class="coda-result-item"><a href="${link}" target="_blank">${escapeHtml(t)}</a></div>`;
-                    }).join('');
+                    }).join("");
                 })
                 .catch(err => {
-                    results.textContent = 'Error';
-                    console.error('[Copilot] Coda search error:', err);
+                    results.textContent = "Error";
+                    console.error("[Copilot] Coda search error:", err);
                 });
         };
         btn.addEventListener('click', runSearch);


### PR DESCRIPTION
## Summary
- log CODA API query and response inside `openCodaSearch`
- mention new CODA search logs in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859ad251eec83268d279c0c31aff7e6