### PR TITLE
Fix client info display in review mode

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -35,6 +35,8 @@ information scraped from the current page.
   "No results".
 - CODA Search now logs the query and API status in the console. Look for
   `[Copilot] CODA search` messages to confirm access.
+- Email and phone are shown separately in the Client section.
+- Billing address displays both lines with USPS verification.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.
 ## Known limitations

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1951,6 +1951,10 @@
                         const em = text.match(/[\w.+-]+@[\w.-]+\.[\w.-]+(?=\s|$)/);
                         if (em) email = em[0];
                     }
+                    if (email) {
+                        const clean = email.match(/[\w.+-]+@[\w.-]+\.[\w.-]+/);
+                        if (clean) email = clean[0];
+                    }
                     const ph = text.match(/\(?\d{3}\)?[-\s.]?\d{3}[-\s.]?\d{4}/);
                     if (ph) phone = ph[0];
                 }


### PR DESCRIPTION
## Summary
- parse client email safely to keep phone out
- note in README about separate email/phone and full billing address

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b37b1e7883268c0006a3965404b5