### PR TITLE
Extend diagnose overlay to amendment review orders

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -73,3 +73,4 @@
 - Network Transactions wait for the DNA page to fully load so details appear consistently.
 - Fixed the CLIENT summary combining email and phone when DB separates them with a <br> tag.
 - Fixed mailto links including the phone number when contact info is wrapped in a single anchor.
+- Diagnose overlay now lists amendment orders in review and the cancel tag was renamed to "RESOLVE AND COMMENT".

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -23,7 +23,7 @@ information scraped from the current page.
 - Bento Mode uses a holographic video background that plays at 0.2x speed and reverses at each end.
   The FENNEC header and all summary boxes appear above the video in black containers with 95% opacity and
   white text.
-- Family Tree panel shows related orders and can diagnose holds.
+- Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.
 - Card holder name now appears in bold followed by concise card details for easier reading.

--- a/FENNEC-main 31/core/utils.js
+++ b/FENNEC-main 31/core/utils.js
@@ -166,12 +166,17 @@ function attachCommonListeners(rootEl) {
                 const diagBtn = container.querySelector('#ar-diagnose-btn');
                 if (diagBtn && typeof diagnoseHoldOrders === 'function') {
                     diagBtn.addEventListener('click', () => {
-                        const holds = resp.childOrders.filter(o => /hold/i.test(o.status));
-                        if (!holds.length) {
-                            alert('No HOLD orders found');
+                        const relevant = resp.childOrders.filter(o => {
+                            const status = o.status || '';
+                            const type = o.type || '';
+                            return /hold/i.test(status) ||
+                                (/amendment/i.test(type) && /review/i.test(status));
+                        });
+                        if (!relevant.length) {
+                            alert('No applicable orders found');
                             return;
                         }
-                        diagnoseHoldOrders(holds);
+                        diagnoseHoldOrders(relevant);
                     });
                 }
             });

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -45,3 +45,4 @@ DNA        → Shortcut button that opens Adyen payment details and shopper DNA
 Network Transactions → Counts and amounts from the DNA page Network section
 CODA Search → Menu option to query the KB via the Coda API
 Coda API token → Authentication key required for CODA Search
+Amendment orders → Changes to existing filings processed through the DB

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -2026,11 +2026,11 @@
             issueDiv.textContent = r.issue;
             card.appendChild(issueDiv);
 
-            const cancel = document.createElement('span');
-            cancel.className = 'copilot-tag copilot-tag-red diag-cancel';
-            cancel.textContent = 'CANCEL';
-            cancel.addEventListener('click', startCancelProcedure);
-            card.appendChild(cancel);
+            const resolve = document.createElement('span');
+            resolve.className = 'copilot-tag copilot-tag-green diag-resolve';
+            resolve.textContent = 'RESOLVE AND COMMENT';
+            resolve.addEventListener('click', startCancelProcedure);
+            card.appendChild(resolve);
 
             overlay.appendChild(card);
         };

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -510,7 +510,7 @@
     margin-bottom: 4px;
 }
 
-#fennec-diagnose-overlay .diag-cancel {
+#fennec-diagnose-overlay .diag-resolve {
     cursor: pointer;
     margin-top: 6px;
     display: inline-block;


### PR DESCRIPTION
## Summary
- update diagnose button logic to include amendment orders in review
- replace CANCEL tag with green RESOLVE AND COMMENT
- note new behavior in README and changelog
- add glossary entry for amendment orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859b455aae08326aafa80e4fe73e2ee