### PR TITLE
Improve CODA search errors

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -35,6 +35,9 @@ information scraped from the current page.
   "No results".
 - CODA Search now logs the query and API status in the console. Look for
   `[Copilot] CODA search` messages to confirm access.
+- When the API request fails the results panel shows the status code and
+  message so you know if the document ID is invalid or the token needs to be
+  updated.
 - Email and phone are shown separately in the Client section.
 - Billing address shows the full street line followed by city, state, zip and
   country. The address remains clickable and includes USPS verification.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1747,10 +1747,16 @@
             })
                 .then(r => {
                     console.log("[Copilot] CODA search status:", r.status);
-                    return r.json();
+                    const status = r.status;
+                    return r.json().catch(() => ({})).then(data => ({ status, data }));
                 })
-                .then(data => {
+                .then(({ status, data }) => {
                     console.log("[Copilot] CODA search response:", data);
+                    if (status !== 200) {
+                        const msg = data && data.message ? data.message : "API request failed";
+                        results.textContent = `Error ${status}: ${msg}`;
+                        return;
+                    }
                     if (!data || !data.items || !data.items.length) {
                         results.textContent = "No results";
                         return;
@@ -1762,7 +1768,7 @@
                     }).join("");
                 })
                 .catch(err => {
-                    results.textContent = "Error";
+                    results.textContent = "Network error";
                     console.error("[Copilot] Coda search error:", err);
                 });
         };


### PR DESCRIPTION
## Summary
- show API status codes and messages in CODA search results
- document search failure info in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859be8cd5308326af4733f6bb1c0ee7