### PR TITLE
Fix billing address in Gmail

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -74,3 +74,4 @@
 - Fixed the CLIENT summary combining email and phone when DB separates them with a <br> tag.
 - Fixed mailto links including the phone number when contact info is wrapped in a single anchor.
 - Diagnose overlay now lists amendment orders in review and the cancel tag was renamed to "RESOLVE AND COMMENT".
+- Fixed billing address in Gmail Review Mode to include the street line.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1657,7 +1657,7 @@
             expiry: raw.expiry,
             last4: raw.last4,
             address: buildAddress(raw),
-            street1: raw.street1 || raw.street,
+            street1: raw.street1 || raw.street || raw.address,
             street2: raw.street2,
             cityStateZipCountry: raw.cityStateZipCountry,
             cityStateZip: raw.cityStateZip,


### PR DESCRIPTION
## Summary
- ensure DB extraction uses the Address field when Street 1 is missing
- document the billing address fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c606d7f083269d1816e5827bc5e1