### PR TITLE
Enhance DNA summary comparison

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -28,6 +28,7 @@ information scraped from the current page.
 - The DNA summary is inserted below the Billing section once data is available.
 - Card holder name now appears in bold followed by concise card details for easier reading.
 - Network transactions from the DNA page appear in the summary.
+- A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token. Generate

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -46,3 +46,4 @@ Network Transactions → Counts and amounts from the DNA page Network section
 CODA Search → Menu option to query the KB via the Coda API
 Coda API token → Authentication key required for CODA Search
 Amendment orders → Changes to existing filings processed through the DB
+DNA Match Tag → Label indicating if Billing details agree with the DNA data


### PR DESCRIPTION
## Summary
- adjust card number display to show just the last four digits
- format billing address as two lines
- compare DB billing info with Adyen DNA data and show a tag
- document the new DNA match tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c7a76bc88326848fac098979fb8c