### PR TITLE
Fix Coda doc ID

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -32,9 +32,10 @@ information scraped from the current page.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.
 - CODA Search menu item queries the knowledge base using the Coda API.
-- Edit `environments/db/db_launcher.js` to provide your Coda API token. Generate
-  a new token in Coda and replace the value after `Bearer` if searches return
-  "No results".
+- Edit `environments/db/db_launcher.js` to provide your Coda API token and the
+  Coda doc ID. Generate a new token in Coda and replace the value after
+  `Bearer` if searches return "No results". Set the doc ID without the leading
+  `d` (for example `QJWsDF3UZ6`).
 - CODA Search now logs the query and API status in the console. Look for
   `[Copilot] CODA search` messages to confirm access.
 - When the API request fails the results panel shows the status code and

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -45,6 +45,7 @@ DNA        → Shortcut button that opens Adyen payment details and shopper DNA
 Network Transactions → Counts and amounts from the DNA page Network section
 CODA Search → Menu option to query the KB via the Coda API
 Coda API token → Authentication key required for CODA Search
+Coda doc ID → Identifier of the Coda document searched by CODA Search
 Amendment orders → Changes to existing filings processed through the DB
 DNA Match Tag → Label indicating if Billing details agree with the DNA data
 Transaction table → Colored summary of Adyen transactions

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1742,7 +1742,7 @@
             if (!q) return;
             results.textContent = "Loading...";
             console.log("[Copilot] CODA search query:", q);
-            fetch("https://coda.io/apis/v1/docs/dQJWsDF3UZ6/search?q=" + encodeURIComponent(q), {
+            fetch("https://coda.io/apis/v1/docs/QJWsDF3UZ6/search?q=" + encodeURIComponent(q), {
                 headers: { "Authorization": "Bearer 758d99dd-34d0-43a5-8896-595785019945" }
             })
                 .then(r => {


### PR DESCRIPTION
## Summary
- correct the Coda doc ID used for CODA Search
- document how to set the doc ID in README
- add glossary entry for Coda doc ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d1587d048326bdf9d5dcbae9a3bc