### PR TITLE
Refine DNA summary layout

### DIFF
--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -334,12 +334,21 @@
 .dna-tx-table{
     width:100%;
     border-collapse:collapse;
-    margin-top:6px;
+    margin:6px auto 0;
+    text-align:center;
 }
 .dna-tx-table th,.dna-tx-table td{
     padding:2px 4px;
     font-size:12px;
-    text-align:left;
+    text-align:center;
+}
+.tx-label{
+    min-width:100px;
+    text-align:center;
+}
+.dna-issuer{
+    font-size:11px;
+    margin-top:2px;
 }
 
 .issue-status-label {


### PR DESCRIPTION
## Summary
- improve formatting of Adyen DNA transactions
- show issuing bank and country after the match label
- colour CVV/AVS statuses and hide IP line
- center and size DNA transaction table via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859d94fb67c83269baa689902aa75b2