### PR TITLE
Improve DNA summary layout and focus handling

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -75,4 +75,7 @@
 - Fixed mailto links including the phone number when contact info is wrapped in a single anchor.
 - Diagnose overlay now lists amendment orders in review and the cancel tag was renamed to "RESOLVE AND COMMENT".
 - Fixed billing address in Gmail Review Mode to include the street line.
-    - CODA Search token updated for API access.
+- CODA Search token updated for API access.
+- DNA summary now shows between the DNA button and Company section.
+- CVV and AVS tags use the normal font size with dark gray text for white labels.
+- Focus returns to the email tab automatically after the DNA page loads.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -25,11 +25,13 @@ information scraped from the current page.
   white text.
 - Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
 - Review Mode merges order details and fetches Adyen DNA data.
-- The DNA summary now appears above the Company section once data is available.
+- The DNA summary now appears between the DNA button and the Company section once data is available.
 - Card holder name now appears in bold followed by concise card details for easier reading.
 - Network transactions from the DNA page appear in the summary.
 - Transactions now display in a table with colored tags for each type.
 - Billing match tag now appears next to the cardholder name, with bank and country initials below the billing address. CVV and AVS results show on one line.
+- CVV and AVS tags use the normal font size and white labels now show dark gray text.
+- After the DNA page loads the extension returns focus to the original email tab.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.
 - CODA Search menu item queries the knowledge base using the Coda API.

--- a/FENNEC-main 31/core/background_emailsearch.js
+++ b/FENNEC-main 31/core/background_emailsearch.js
@@ -13,6 +13,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 console.error("[Copilot] Error (openTab):", chrome.runtime.lastError.message);
             }
         });
+        if (message.refocus && sender && sender.tab) {
+            chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
+        }
     }
 
     if (message.action === "openActiveTab" && message.url) {
@@ -452,6 +455,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 }
             };
             chrome.tabs.onUpdated.addListener(listener);
+        });
+        return;
+    }
+
+    if (message.action === "refocusTab") {
+        chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
+            if (fennecReturnTab) {
+                chrome.tabs.update(fennecReturnTab, { active: true }, () => {
+                    if (chrome.runtime.lastError) {
+                        console.error("[Copilot] Error focusing tab:", chrome.runtime.lastError.message);
+                    }
+                });
+            }
         });
         return;
     }

--- a/FENNEC-main 31/environments/adyen/adyen_launcher.js
+++ b/FENNEC-main 31/environments/adyen/adyen_launcher.js
@@ -161,6 +161,7 @@
                     const networkTx = extractNetworkTransactions();
                     saveData({ transactions: stats, networkTransactions: networkTx, updated: Date.now() });
                     console.log('[FENNEC Adyen] DNA stats stored');
+                    chrome.runtime.sendMessage({ action: 'refocusTab' });
                 });
             }
 

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -753,16 +753,16 @@
         }
 
         function repositionDnaSummary() {
-            const summary = document.getElementById("dna-summary");
-            if (!summary) return;
-            const container = document.getElementById("db-summary-section");
-            if (!container) return;
-            const compLabel = Array.from(container.querySelectorAll(".section-label"))
-                .find(el => el.textContent.trim().startsWith("COMPANY"));
-            if (compLabel) {
-                compLabel.insertAdjacentElement("beforebegin", summary);
-            } else {
-                container.prepend(summary);
+            const dnaBox = document.querySelector('.copilot-dna');
+            const summary = document.getElementById('dna-summary');
+            if (!dnaBox || !summary) return;
+            if (summary.parentElement !== dnaBox) {
+                dnaBox.appendChild(summary);
+            }
+            const compLabel = Array.from(document.querySelectorAll('#copilot-sidebar .section-label'))
+                .find(el => el.textContent.trim().startsWith('COMPANY'));
+            if (compLabel && dnaBox.nextElementSibling !== compLabel) {
+                compLabel.parentElement.insertBefore(dnaBox, compLabel);
             }
         }
 
@@ -869,12 +869,12 @@
                 if (cvv) {
                     const cls = matchColor(cvv);
                     const text = `CVV: ${cvv}`;
-                    tags.push(`<span class="copilot-tag ${cls}"><b>${escapeHtml(text)}</b></span>`);
+                    tags.push(`<span class="copilot-tag copilot-tag-large ${cls}">${escapeHtml(text)}</span>`);
                 }
                 if (avs) {
                     const cls = matchColor(avs);
                     const text = `AVS: ${avs}`;
-                    tags.push(`<span class="copilot-tag ${cls}"><b>${escapeHtml(text)}</b></span>`);
+                    tags.push(`<span class="copilot-tag copilot-tag-large ${cls}">${escapeHtml(text)}</span>`);
                 }
                 parts.push(`<div>${tags.join(' ')}</div>`);
             }
@@ -1229,7 +1229,7 @@
                     console.log('[Copilot] Opening Adyen for order', orderId);
                     const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
                     showDnaLoading();
-                    chrome.runtime.sendMessage({ action: "openTab", url });
+                    chrome.runtime.sendMessage({ action: "openTab", url, refocus: true });
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -308,13 +308,16 @@
     margin-top: 2px;
     opacity: 0.95;
 }
+.copilot-tag-large {
+    font-size: 13px;
+}
 .copilot-tag-green {
     background-color: #2ecc71;
     color: #fff;
 }
 .copilot-tag-white {
     background-color: #fff;
-    color: #000 !important;
+    color: #555 !important;
     opacity: 1;
     border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- refocus the email tab automatically once Adyen DNA data loads
- show DNA summary directly between the DNA button and Company section
- ensure CVV and AVS tags use normal font size
- keep white labels dark gray
- document changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac159f9c4832688eca83edc050bf3