### PR TITLE
Fix quick summary duplication

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Fixed billing address in Gmail Review Mode to include the street line.
 - CODA Search token updated for API access.
 - Fixed order summary duplicating when pressing **EMAIL SEARCH** more than once.
+- Fixed **QUICK SUMMARY** duplicating when pressing **EMAIL SEARCH** repeatedly.
 - CODA Search token updated for API access.
 - DNA summary now shows between the DNA button and Company section.
 - CVV and AVS tags use the normal font size with dark gray text for white labels.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -734,6 +734,7 @@
         function loadDbSummary(expectedId) {
             const container = document.getElementById('db-summary-section');
             if (!container) return;
+            document.querySelectorAll('#copilot-sidebar #quick-summary').forEach(el => el.remove());
             chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null, sidebarOrderInfo: null }, ({ sidebarDb, sidebarOrderId, sidebarOrderInfo }) => {
                 if (Array.isArray(sidebarDb) && sidebarDb.length && (!expectedId || sidebarOrderId === expectedId)) {
                     container.innerHTML = sidebarDb.join("");


### PR DESCRIPTION
## Summary
- remove existing quick summary before loading DB summary in Gmail
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac42f0b3883269f95b6b7bafb5729