### PR TITLE
Open Adyen DNA tab actively

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -82,3 +82,4 @@
 - DNA summary now shows between the DNA button and Company section.
 - CVV and AVS tags use the normal font size with dark gray text for white labels.
 - Focus returns to the email tab automatically after the DNA page loads.
+- DNA pages now open in front before returning focus to the original tab.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -31,7 +31,7 @@ information scraped from the current page.
 - Transactions now display in a table with colored tags for each type.
 - Billing match tag now appears next to the cardholder name, with bank and country initials below the billing address. CVV and AVS results show on one line.
 - CVV and AVS tags use the normal font size and white labels now show dark gray text.
-- After the DNA page loads the extension returns focus to the original email tab.
+- DNA pages open in front and focus returns to the original email tab after transactions load.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.
 - CODA Search menu item queries the knowledge base using the Coda API.

--- a/FENNEC-main 31/core/background_emailsearch.js
+++ b/FENNEC-main 31/core/background_emailsearch.js
@@ -2,7 +2,7 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "openTab" && message.url) {
         console.log("[Copilot] Forzando apertura de una pestaña:", message.url);
-        const opts = { url: message.url, active: false };
+        const opts = { url: message.url, active: Boolean(message.active) };
         if (message.windowId) {
             opts.windowId = message.windowId;
         } else if (sender && sender.tab) {

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -1234,7 +1234,7 @@
                     console.log('[Copilot] Opening Adyen for order', orderId);
                     const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
                     showDnaLoading();
-                    chrome.runtime.sendMessage({ action: "openTab", url, refocus: true });
+                    chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");


### PR DESCRIPTION
## Summary
- open tabs via `openTab` action with an `active` flag
- open Adyen DNA tab in front of Gmail
- document front‑focused DNA behavior
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac5b3655c832687ee004f2bffa848