### PR TITLE
Fix DNA summary placement and loading

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -25,7 +25,7 @@ information scraped from the current page.
   white text.
 - Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
 - Review Mode merges order details and fetches Adyen DNA data.
-- The DNA summary now appears between the DNA button and the Company section once data is available.
+- The DNA summary now appears above the DNA button once data is available.
 - Card holder name now appears in bold followed by concise card details for easier reading.
 - Network transactions from the DNA page appear in the summary.
 - Transactions now display in a table with colored tags for each type.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -757,8 +757,9 @@
             const dnaBox = document.querySelector('.copilot-dna');
             const summary = document.getElementById('dna-summary');
             if (!dnaBox || !summary) return;
-            if (summary.parentElement !== dnaBox) {
-                dnaBox.appendChild(summary);
+            const dnaBtn = dnaBox.querySelector('#btn-dna');
+            if (summary.parentElement !== dnaBox || (dnaBtn && summary.nextElementSibling !== dnaBtn)) {
+                if (dnaBtn) dnaBox.insertBefore(summary, dnaBtn); else dnaBox.appendChild(summary);
             }
             const compLabel = Array.from(document.querySelectorAll('#copilot-sidebar .section-label'))
                 .find(el => el.textContent.trim().startsWith('COMPANY'));
@@ -870,12 +871,12 @@
                 if (cvv) {
                     const cls = matchColor(cvv);
                     const text = `CVV: ${cvv}`;
-                    tags.push(`<span class="copilot-tag copilot-tag-large ${cls}">${escapeHtml(text)}</span>`);
+                    tags.push(`<span class="copilot-tag ${cls}">${escapeHtml(text)}</span>`);
                 }
                 if (avs) {
                     const cls = matchColor(avs);
                     const text = `AVS: ${avs}`;
-                    tags.push(`<span class="copilot-tag copilot-tag-large ${cls}">${escapeHtml(text)}</span>`);
+                    tags.push(`<span class="copilot-tag ${cls}">${escapeHtml(text)}</span>`);
                 }
                 parts.push(`<div>${tags.join(' ')}</div>`);
             }
@@ -968,8 +969,9 @@
                 summary = document.createElement('div');
                 summary.id = 'dna-summary';
                 summary.style.marginTop = '6px';
-                dnaBox.appendChild(summary);
             }
+            const dnaBtn = dnaBox.querySelector('#btn-dna');
+            if (dnaBtn) dnaBox.insertBefore(summary, dnaBtn); else dnaBox.appendChild(summary);
             summary.innerHTML = `<img src="${chrome.runtime.getURL('fennec_icon.png')}" class="loading-fennec"/>`;
             chrome.storage.local.set({ adyenDnaInfo: null });
             repositionDnaSummary();
@@ -991,7 +993,12 @@
             if (orderBox) orderBox.innerHTML = icon;
             if (dbBox) dbBox.innerHTML = icon;
             if (issueContent) issueContent.innerHTML = icon;
-            if (dnaBox) showDnaLoading();
+            if (dnaBox) {
+                const summary = dnaBox.querySelector('#dna-summary');
+                if (summary) summary.innerHTML = '';
+                chrome.storage.local.set({ adyenDnaInfo: null });
+                repositionDnaSummary();
+            }
             if (issueLabel) {
                 issueLabel.textContent = '';
                 issueLabel.className = 'issue-status-label';


### PR DESCRIPTION
## Summary
- keep the DNA summary above the DNA button
- prevent flashing fennec when using EMAIL SEARCH
- reduce CVV/AVS tag size
- update README about DNA summary location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acb7deb408326827a7783deca1d72