### PR TITLE
Add XRAY button for Gmail review mode

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -83,3 +83,4 @@
 - CVV and AVS tags use the normal font size with dark gray text for white labels.
 - Focus returns to the email tab automatically after the DNA page loads.
 - DNA pages now open in front before returning focus to the original tab.
+- Gmail Review Mode now hides **OPEN ORDER** and adds a **🩻 XRAY** button that runs **EMAIL SEARCH** followed by **DNA**.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -34,6 +34,7 @@ information scraped from the current page.
 - DNA pages open in front and focus returns to the original email tab after transactions load.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.
+- When Review Mode is enabled a **🩻 XRAY** button runs **EMAIL SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the
   Coda doc ID. Generate a new token in Coda and replace the value after

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -229,7 +229,10 @@
             if (orderBoxEl) orderBoxEl.style.marginTop = reviewMode ? "4px" : "12px";
             const dnaRow = document.querySelector("#copilot-sidebar .copilot-dna");
             const dnaBtn = document.getElementById("btn-dna");
+            const xrayBtn = document.getElementById("btn-xray");
+            const openOrder = document.getElementById("btn-open-order");
             if (reviewMode) {
+                if (openOrder) openOrder.style.display = "none";
                 if (dnaRow && !dnaBtn) {
                     const btn = document.createElement("button");
                     btn.id = "btn-dna";
@@ -239,9 +242,21 @@
                     setupDnaButton();
                     loadDnaSummary();
                 }
-            } else if (dnaBtn) {
-                dnaBtn.remove();
-                refreshSidebar();
+                if (dnaRow && !xrayBtn) {
+                    const xbtn = document.createElement("button");
+                    xbtn.id = "btn-xray";
+                    xbtn.className = "copilot-button";
+                    xbtn.textContent = "🩻 XRAY";
+                    dnaRow.appendChild(xbtn);
+                    setupXrayButton();
+                }
+            } else {
+                if (openOrder) openOrder.style.display = "";
+                if (dnaBtn) {
+                    dnaBtn.remove();
+                    refreshSidebar();
+                }
+                if (xrayBtn) xrayBtn.remove();
             }
             chrome.storage.sync.set({ fennecReviewMode: reviewMode });
             updateDetailVisibility();
@@ -1246,6 +1261,19 @@
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");
                 }
+            });
+        }
+
+        function setupXrayButton() {
+            const button = document.getElementById("btn-xray");
+            if (!button || button.dataset.listenerAttached) return;
+            button.dataset.listenerAttached = "true";
+            button.addEventListener("click", function () {
+                handleEmailSearchClick();
+                setTimeout(() => {
+                    const dnaBtn = document.getElementById("btn-dna");
+                    if (dnaBtn) dnaBtn.click();
+                }, 500);
             });
         }
 


### PR DESCRIPTION
## Summary
- hide the OPEN ORDER button in Gmail Review Mode
- add an XRAY button next to DNA that runs EMAIL SEARCH and DNA
- document the XRAY button in the README
- note the new button in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acd5de81083269d7a5940b3944465