### PR TITLE
Fix DNA summary placement

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -79,7 +79,7 @@
 - Fixed order summary duplicating when pressing **EMAIL SEARCH** more than once.
 - Fixed **QUICK SUMMARY** duplicating when pressing **EMAIL SEARCH** repeatedly.
 - CODA Search token updated for API access.
-- DNA summary now shows between the DNA button and Company section.
+- DNA summary now shows two lines below the XRAY button and resets on new Gmail tabs.
 - CVV and AVS tags use the normal font size with dark gray text for white labels.
 - Focus returns to the email tab automatically after the DNA page loads.
 - DNA pages now open in front before returning focus to the original tab.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -25,7 +25,8 @@ information scraped from the current page.
   white text.
 - Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
 - Review Mode merges order details and fetches Adyen DNA data.
-- The DNA summary now appears above the DNA button once data is available.
+- The DNA summary now appears two lines below the XRAY button.
+- The DNA summary resets when opening a new Gmail tab.
 - Card holder name now appears in bold followed by concise card details for easier reading.
 - Network transactions from the DNA page appear in the summary.
 - Transactions now display in a table with colored tags for each type.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -35,6 +35,7 @@
             reviewMode = reviewMode === null ? fennecReviewMode : reviewMode === 'true';
             let currentContext = null;
             let storedOrderInfo = null;
+            chrome.storage.local.set({ adyenDnaInfo: null });
 
             // Map of US states to their SOS business search pages
             const SOS_URLS = {
@@ -773,8 +774,13 @@
             const summary = document.getElementById('dna-summary');
             if (!dnaBox || !summary) return;
             const dnaBtn = dnaBox.querySelector('#btn-dna');
-            if (summary.parentElement !== dnaBox || (dnaBtn && summary.nextElementSibling !== dnaBtn)) {
-                if (dnaBtn) dnaBox.insertBefore(summary, dnaBtn); else dnaBox.appendChild(summary);
+            const xrayBtn = dnaBox.querySelector('#btn-xray');
+            const afterBtn = xrayBtn || dnaBtn;
+            if (afterBtn) {
+                const next = afterBtn.nextSibling;
+                if (next !== summary) dnaBox.insertBefore(summary, next);
+            } else if (summary.parentElement !== dnaBox) {
+                dnaBox.appendChild(summary);
             }
             const compLabel = Array.from(document.querySelectorAll('#copilot-sidebar .section-label'))
                 .find(el => el.textContent.trim().startsWith('COMPANY'));
@@ -983,10 +989,12 @@
             if (!summary) {
                 summary = document.createElement('div');
                 summary.id = 'dna-summary';
-                summary.style.marginTop = '6px';
+                summary.style.marginTop = '16px';
             }
+            const xrayBtn = dnaBox.querySelector('#btn-xray');
             const dnaBtn = dnaBox.querySelector('#btn-dna');
-            if (dnaBtn) dnaBox.insertBefore(summary, dnaBtn); else dnaBox.appendChild(summary);
+            const afterBtn = xrayBtn || dnaBtn;
+            if (afterBtn) dnaBox.insertBefore(summary, afterBtn.nextSibling); else dnaBox.appendChild(summary);
             summary.innerHTML = `<img src="${chrome.runtime.getURL('fennec_icon.png')}" class="loading-fennec"/>`;
             chrome.storage.local.set({ adyenDnaInfo: null });
             repositionDnaSummary();
@@ -1089,7 +1097,7 @@
                         <button id="btn-open-order" class="copilot-button">📂 OPEN ORDER</button>
                     </div>
                     <div class="copilot-dna">
-                        <div id="dna-summary" style="margin-top:6px"></div>
+                        <div id="dna-summary" style="margin-top:16px"></div>
                     </div>
                     <div class="section-label" style="margin:6px 0">COMPANY:</div>
                     <div class="order-summary-header">ORDER SUMMARY</div>
@@ -1208,6 +1216,7 @@
             if (!button) return;
             button.addEventListener("click", function () {
                 try {
+                    showLoadingState();
                     const bodyNode = document.querySelector(".a3s");
                     if (!bodyNode) {
                         alert("No se encontró el cuerpo del correo.");


### PR DESCRIPTION
## Summary
- reset DNA data when Gmail loads and before opening DB order
- move Adyen DNA summary below the XRAY button
- document layout change in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685acfcf97f883268db64ba3b2afad62