### PR TITLE
Add light gray DNA label

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -32,6 +32,7 @@ information scraped from the current page.
 - Transactions now display in a table with colored tags for each type.
 - Billing match tag now appears next to the cardholder name, with bank and country initials below the billing address. CVV and AVS results show on one line.
 - CVV and AVS tags use the normal font size and white labels now show dark gray text.
+- Adyen DNA labels use a light gray tag with black text in Review Mode.
 - DNA pages open in front and focus returns to the original email tab after transactions load.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -49,3 +49,4 @@ Coda doc ID → Identifier of the Coda document searched by CODA Search
 Amendment orders → Changes to existing filings processed through the DB
 DNA Match Tag → Label indicating if Billing details agree with the DNA data
 Transaction table → Colored summary of Adyen transactions
+Light Gray Tag → Label color used for Adyen DNA entries in Review Mode (light gray background with black text)

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -321,6 +321,11 @@
     opacity: 1;
     border: 1px solid #ccc;
 }
+.copilot-tag-lightgray {
+    background-color: #ddd;
+    color: #000;
+    border: 1px solid #bbb;
+}
 .copilot-tag-purple {
     background-color: #800080;
     color: #fff;

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -70,6 +70,11 @@
     color: #000 !important;
     border: 1px solid #777;
 }
+.fennec-light-mode .copilot-tag-lightgray {
+    background-color: #ddd;
+    color: #000 !important;
+    border: 1px solid #777;
+}
 
 .fennec-light-mode #fennec-diagnose-overlay .diag-order {
     color: #000;


### PR DESCRIPTION
## Summary
- style new `.copilot-tag-lightgray` tag for Adyen DNA
- note light gray tag in README
- document Light Gray Tag in dictionary

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ad16158188326a1e107b2d9aafa01