### PR TITLE
Implement knowledge base overlay

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -84,3 +84,4 @@
 - Focus returns to the email tab automatically after the DNA page loads.
 - DNA pages now open in front before returning focus to the original tab.
 - Gmail Review Mode now hides **OPEN ORDER** and adds a **🩻 XRAY** button that runs **EMAIL SEARCH** followed by **DNA**.
+- Clicking the state in DB SB now opens the Coda Knowledge Base in a floating overlay covering 66% of the page.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -38,6 +38,7 @@ information scraped from the current page.
 - A Refresh button updates information without reloading the page.
 - When Review Mode is enabled a **🩻 XRAY** button runs **EMAIL SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden.
 - CODA Search menu item queries the knowledge base using the Coda API.
+- Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a floating overlay that covers two-thirds of the page. The DB view dims and the sidebar remains visible.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the
   Coda doc ID. Generate a new token in Coda and replace the value after
   `Bearer` if searches return "No results". Set the doc ID without the leading

--- a/FENNEC-main 31/core/utils.js
+++ b/FENNEC-main 31/core/utils.js
@@ -53,7 +53,11 @@ function attachCommonListeners(rootEl) {
             const state = el.dataset.state;
             const otype = el.dataset.otype || '';
             if (!state) return;
-            chrome.runtime.sendMessage({ action: 'openKnowledgeBase', state, orderType: otype });
+            if (typeof window.openKbOverlay === 'function') {
+                window.openKbOverlay(state, otype);
+            } else {
+                chrome.runtime.sendMessage({ action: 'openKnowledgeBase', state, orderType: otype });
+            }
         });
     });
     rootEl.querySelectorAll('.company-purpose .copilot-copy').forEach(el => {

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -50,3 +50,4 @@ Amendment orders → Changes to existing filings processed through the DB
 DNA Match Tag → Label indicating if Billing details agree with the DNA data
 Transaction table → Colored summary of Adyen transactions
 Light Gray Tag → Label color used for Adyen DNA entries in Review Mode (light gray background with black text)
+Knowledge Base overlay → Floating panel that displays the Coda Knowledge Base over the DB page

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1776,6 +1776,35 @@
         input.addEventListener('keydown', e => { if (e.key === 'Enter') runSearch(); });
     }
 
+    // Opens the Coda knowledge base in a floating iframe overlay
+    function openKbOverlay(state, type) {
+        let back = document.getElementById('fennec-kb-backdrop');
+        let overlay = document.getElementById('fennec-kb-overlay');
+        if (overlay) overlay.remove();
+        if (back) back.remove();
+        back = document.createElement('div');
+        back.id = 'fennec-kb-backdrop';
+        back.addEventListener('click', () => {
+            overlay.remove();
+            back.remove();
+        });
+        overlay = document.createElement('div');
+        overlay.id = 'fennec-kb-overlay';
+        const close = document.createElement('div');
+        close.className = 'kb-close';
+        close.textContent = '✕';
+        close.addEventListener('click', () => {
+            overlay.remove();
+            back.remove();
+        });
+        overlay.appendChild(close);
+        const frame = document.createElement('iframe');
+        frame.src = 'https://coda.io/d/Bizee-Filing-Department_dQJWsDF3UZ6/Knowledge-Base_suQao1ou';
+        overlay.appendChild(frame);
+        document.body.appendChild(back);
+        document.body.appendChild(overlay);
+    }
+
     function getLastIssueInfo() {
         function parseRow(row) {
             const cells = row.querySelectorAll('td');
@@ -2109,6 +2138,7 @@ function getLastHoldUser() {
     // Expose helpers so core/utils.js can access them
     window.getParentOrderId = getParentOrderId;
     window.diagnoseHoldOrders = diagnoseHoldOrders;
+    window.openKbOverlay = openKbOverlay;
 
 chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.fennecReviewMode) {

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -603,3 +603,46 @@
 #fennec-coda-overlay .coda-result-item a {
     color: #4da3ff;
 }
+
+#fennec-kb-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.4);
+    z-index: 1064;
+}
+
+#fennec-kb-overlay {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 66%;
+    height: 66%;
+    max-height: 90%;
+    background: #2e2e2e;
+    color: #f1f1f1;
+    border: 1px solid gray;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    overflow: hidden;
+    z-index: 1065;
+}
+
+#fennec-kb-overlay .kb-close {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    color: #fff;
+    z-index: 1066;
+}
+
+#fennec-kb-overlay iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -59,6 +59,15 @@
     display: none;
 }
 
+.fennec-light-mode #fennec-kb-overlay {
+    background: #fff;
+    color: #000 !important;
+    border: 1px solid #777;
+}
+.fennec-light-mode #fennec-kb-overlay .kb-close {
+    color: #000;
+}
+
 /* Ensure status labels remain visible */
 .fennec-light-mode #copilot-sidebar .issue-status-label,
 .fennec-light-mode #copilot-sidebar .review-mode-label {


### PR DESCRIPTION
## Summary
- keep state link in the DB sidebar on the page and open the Coda Knowledge Base in an overlay
- expose an `openKbOverlay` helper to the DB scripts
- dim the DB page with a backdrop and style the overlay in normal and light mode
- document the new behavior in README and CHANGELOG
- update dictionary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad3280d6483269e5b569d7a7b04e4