### PR TITLE
Fix total label color

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -35,6 +35,7 @@ information scraped from the current page.
 - Billing match tag now appears next to the cardholder name, with bank and country initials below the billing address. CVV and AVS results show on one line.
 - CVV and AVS tags use the normal font size and white labels now show dark gray text.
 - Adyen DNA labels use a light gray tag with black text in Review Mode.
+- The "Total" label in DNA transaction tables now uses the light gray tag.
 - DNA pages open in front and focus returns to the original email tab after transactions load.
 - A tag below the DNA section shows if the billing card info matches.
 - A Refresh button updates information without reloading the page.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -795,7 +795,7 @@
         function buildTransactionTable(tx) {
             if (!tx) return "";
             const colors = {
-                "Total": "white",
+                "Total": "lightgray",
                 "Authorised / Settled": "green",
                 "Settled": "green",
                 "Refused": "red",


### PR DESCRIPTION
## Summary
- style the DNA `Total` transaction label with the light gray tag
- document the label change in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685adc58e1548326b5255082255d2f0e