### PR TITLE
Fix lightgray labels in light mode

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -87,3 +87,4 @@
 - DNA pages now open in front before returning focus to the original tab.
 - Gmail Review Mode now hides **OPEN ORDER** and adds a **🩻 XRAY** button that runs **EMAIL SEARCH** followed by **DNA**.
 - Clicking the state in DB SB now opens the Coda Knowledge Base in a separate window sized like a third column.
+- Light gray labels now display black text in Light Mode.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -35,6 +35,7 @@ information scraped from the current page.
 - Transactions now display in a table with colored tags for each type.
 - Billing match tag now appears next to the cardholder name, with bank and country initials below the billing address. CVV and AVS results show on one line.
 - CVV and AVS tags use the normal font size and white labels now show dark gray text.
+- Light gray labels in Light Mode now keep black text for readability.
 - Adyen DNA labels use a light gray tag with black text in Review Mode.
 - The "Total" label in DNA transaction tables now uses the light gray tag.
 - DNA pages open in front and focus returns to the original email tab after transactions load.

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -74,12 +74,12 @@
     color: #fff !important;
 }
 
-.fennec-light-mode .copilot-tag-white {
+.fennec-light-mode #copilot-sidebar .copilot-tag-white {
     background-color: #fff;
     color: #000 !important;
     border: 1px solid #777;
 }
-.fennec-light-mode .copilot-tag-lightgray {
+.fennec-light-mode #copilot-sidebar .copilot-tag-lightgray {
     background-color: #ddd;
     color: #000 !important;
     border: 1px solid #777;


### PR DESCRIPTION
## Summary
- ensure lightgray tag text stays black while in Light Mode
- document label color fix
- note the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae0f6f7488326bfad1adddda5d3d5