### PR TITLE
Implement Comment Box for Family Tree diagnose

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -24,7 +24,7 @@ information scraped from the current page.
   The FENNEC header and all summary boxes appear above the video in black containers with 95% opacity and
   white text.
 - Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
-- Diagnose overlay includes a default "AR COMPLETED" comment field that opens the child order and resolves the issue.
+- Diagnose overlay now shows a black text Comment Box prefilled with **AR COMPLETED** and the parent order number. Pressing **RESOLVE AND COMMENT** opens the child order, marks the issue resolved and adds that comment to the order.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary now appears two lines below the XRAY button.
 - The DNA summary resets when opening a new Gmail tab.

--- a/FENNEC-main 31/core/utils.js
+++ b/FENNEC-main 31/core/utils.js
@@ -180,7 +180,7 @@ function attachCommonListeners(rootEl) {
                             alert('No applicable orders found');
                             return;
                         }
-                        diagnoseHoldOrders(relevant);
+                        diagnoseHoldOrders(relevant, parent.orderId);
                     });
                 }
             });

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -53,3 +53,5 @@ Light Gray Tag → Label color used for Adyen DNA entries in Review Mode (light 
 Knowledge Base window → Separate browser window that shows the Coda Knowledge Base next to the DB page
 
 AR COMPLETED         → Default comment used when resolving a Family Tree order
+Diagnose overlay → Floating panel listing Family Tree hold orders
+Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the parent order number

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1734,11 +1734,37 @@
                 ta.value = comment;
                 save.click();
                 sessionStorage.removeItem('fennecAutoComment');
+                sessionStorage.setItem('fennecAddComment', comment);
             } else {
                 setTimeout(fillComment, 500);
             }
         };
         clickResolve();
+    }
+
+    function addOrderComment(comment) {
+        const openModal = () => {
+            const btn = Array.from(document.querySelectorAll('a,button'))
+                .find(el => /modalAddNote/.test(el.getAttribute('onclick') || ''));
+            if (btn) {
+                btn.click();
+                fill();
+            } else {
+                setTimeout(openModal, 500);
+            }
+        };
+        const fill = () => {
+            const modal = document.getElementById('modalAddNote');
+            const ta = modal ? modal.querySelector('#commentText') : null;
+            const add = modal ? modal.querySelector('#btnTextSaveComment') : null;
+            if (ta && add) {
+                ta.value = comment;
+                add.click();
+            } else {
+                setTimeout(fill, 500);
+            }
+        };
+        openModal();
     }
 
     function openCodaSearch() {
@@ -2032,7 +2058,7 @@
     }
 
 
-    function diagnoseHoldOrders(orders) {
+    function diagnoseHoldOrders(orders, parentId) {
         let overlay = document.getElementById('fennec-diagnose-overlay');
         if (overlay) overlay.remove();
         overlay = document.createElement('div');
@@ -2083,7 +2109,7 @@
             const commentBox = document.createElement('input');
             commentBox.type = 'text';
             commentBox.className = 'diag-comment';
-            commentBox.value = `AR COMPLETED: ${r.order.orderId}`;
+            commentBox.value = `AR COMPLETED: ${parentId}`;
             card.appendChild(commentBox);
 
             const resolve = document.createElement('span');
@@ -2171,6 +2197,12 @@ chrome.storage.local.get({ fennecPendingComment: null }, ({ fennecPendingComment
         }
     }
 });
+
+const pendingNote = sessionStorage.getItem('fennecAddComment');
+if (pendingNote) {
+    sessionStorage.removeItem('fennecAddComment');
+    setTimeout(() => addOrderComment(pendingNote), 1500);
+}
 
 chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.fennecReviewMode) {

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -558,6 +558,7 @@
     padding: 4px;
     border-radius: 4px;
     border: 1px solid #888;
+    color: #000;
 }
 
 #fennec-diagnose-overlay .diag-issue {


### PR DESCRIPTION
## Summary
- hook Family Tree diagnose button to send the parent order ID
- show comment box defaulting to `AR COMPLETED:` + parent order
- resolve and comment now adds an order comment after resolving
- style the comment box with black text
- document the new behavior and terms in the README and dictionary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aea03649483269a4714710fa7b040