### PR TITLE
Fix light gray tag color

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -88,4 +88,5 @@
 - Gmail Review Mode now hides **OPEN ORDER** and adds a **🩻 XRAY** button that runs **EMAIL SEARCH** followed by **DNA**.
 - Clicking the state in DB SB now opens the Coda Knowledge Base in a separate window sized like a third column.
 - Light gray labels now display black text in Light Mode.
+- Fixed light gray tags in Review Mode inheriting sidebar text color.
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use purple for unknown results, black for partial matches and green for full matches.

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -323,7 +323,7 @@
 }
 .copilot-tag-lightgray {
     background-color: #ddd;
-    color: #000;
+    color: #000 !important;
     border: 1px solid #bbb;
 }
 .copilot-tag-purple {


### PR DESCRIPTION
## Summary
- force black text color on light gray tags so labels remain readable
- document the light gray tag fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af00172b0832680a48f4b9e0ae5c7