### PR TITLE
Improve Diagnose overlay defaults

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Fixed the CLIENT summary combining email and phone when DB separates them with a <br> tag.
 - Fixed mailto links including the phone number when contact info is wrapped in a single anchor.
 - Diagnose overlay now lists amendment orders in review and the cancel tag was renamed to "RESOLVE AND COMMENT".
+- Diagnose overlay comment box now defaults to the current order number and cards are 1.5× wider.
 - Fixed billing address in Gmail Review Mode to include the street line.
 - CODA Search token updated for API access.
 - Fixed order summary duplicating when pressing **EMAIL SEARCH** more than once.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -24,7 +24,7 @@ information scraped from the current page.
   The FENNEC header and all summary boxes appear above the video in black containers with 95% opacity and
   white text.
 - Family Tree panel shows related orders and can diagnose holds, including amendment orders in review.
-- Diagnose overlay now shows a black text Comment Box prefilled with **AR COMPLETED** and the parent order number. Pressing **RESOLVE AND COMMENT** opens the child order, marks the issue resolved and adds that comment to the order.
+- Diagnose overlay now shows a black text Comment Box prefilled with **AR COMPLETED** and the current order number. Cards are 1.5× wider and pressing **RESOLVE AND COMMENT** opens the child order, marks the issue resolved and adds that comment to the order.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary now appears two lines below the XRAY button.
 - The DNA summary resets when opening a new Gmail tab.

--- a/FENNEC-main 31/core/utils.js
+++ b/FENNEC-main 31/core/utils.js
@@ -180,7 +180,10 @@ function attachCommonListeners(rootEl) {
                             alert('No applicable orders found');
                             return;
                         }
-                        diagnoseHoldOrders(relevant, parent.orderId);
+                        const current = typeof getBasicOrderInfo === 'function'
+                            ? getBasicOrderInfo().orderId
+                            : null;
+                        diagnoseHoldOrders(relevant, parent.orderId, current);
                     });
                 }
             });

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -54,4 +54,4 @@ Knowledge Base window → Separate browser window that shows the Coda Knowledge 
 
 AR COMPLETED         → Default comment used when resolving a Family Tree order
 Diagnose overlay → Floating panel listing Family Tree hold orders
-Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the parent order number
+Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the current order number

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -2058,7 +2058,7 @@
     }
 
 
-    function diagnoseHoldOrders(orders, parentId) {
+    function diagnoseHoldOrders(orders, parentId, originId) {
         let overlay = document.getElementById('fennec-diagnose-overlay');
         if (overlay) overlay.remove();
         overlay = document.createElement('div');
@@ -2109,7 +2109,7 @@
             const commentBox = document.createElement('input');
             commentBox.type = 'text';
             commentBox.className = 'diag-comment';
-            commentBox.value = `AR COMPLETED: ${parentId}`;
+            commentBox.value = `AR COMPLETED: ${originId}`;
             card.appendChild(commentBox);
 
             const resolve = document.createElement('span');

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -526,7 +526,7 @@
 #fennec-diagnose-overlay .diag-card {
     display: inline-block;
     vertical-align: top;
-    width: 180px;
+    width: 270px;
     margin: 8px;
     padding: 8px;
     border-radius: 8px;
@@ -553,7 +553,7 @@
 }
 
 #fennec-diagnose-overlay .diag-comment {
-    width: 160px;
+    width: 240px;
     margin-top: 4px;
     padding: 4px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- prefill Comment Box with the current order number
- widen Diagnose overlay cards
- document new default in README and glossary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af14721788326be05cc2f0393c5cc