### PR TITLE
Fix default comment in Diagnose overlay

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -91,3 +91,4 @@
 - Light gray labels now display black text in Light Mode.
 - Fixed light gray tags in Review Mode inheriting sidebar text color.
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use purple for unknown results, black for partial matches and green for full matches.
+- Fixed Diagnose overlay comment box showing **null** instead of the current order number when triggered from the Family Tree panel.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -2059,6 +2059,12 @@
 
 
     function diagnoseHoldOrders(orders, parentId, originId) {
+        // fall back to current order when originId missing
+        if (!originId) {
+            originId = typeof getBasicOrderInfo === 'function'
+                ? getBasicOrderInfo().orderId
+                : parentId;
+        }
         let overlay = document.getElementById('fennec-diagnose-overlay');
         if (overlay) overlay.remove();
         overlay = document.createElement('div');


### PR DESCRIPTION
## Summary
- ensure Diagnose overlay uses the current order when the origin id is missing
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af2d154008326b1b670f00ce4e988