### PR TITLE
Implement new Coda KB overlay

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -87,7 +87,7 @@
 - Focus returns to the email tab automatically after the DNA page loads.
 - DNA pages now open in front before returning focus to the original tab.
 - Gmail Review Mode now hides **OPEN ORDER** and adds a **🩻 XRAY** button that runs **EMAIL SEARCH** followed by **DNA**.
-- Clicking the state in DB SB now opens the Coda Knowledge Base in a separate window sized like a third column.
+- Clicking the state in DB SB now opens the Coda Knowledge Base in a floating overlay covering most of the page.
 - Light gray labels now display black text in Light Mode.
 - Fixed light gray tags in Review Mode inheriting sidebar text color.
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use purple for unknown results, black for partial matches and green for full matches.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -43,7 +43,7 @@ information scraped from the current page.
 - A Refresh button updates information without reloading the page.
  - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
 - CODA Search menu item queries the knowledge base using the Coda API.
-- Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a separate window sized like a third column.
+- Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a floating overlay covering most of the page.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the
   Coda doc ID. Generate a new token in Coda and replace the value after
   `Bearer` if searches return "No results". Set the doc ID without the leading

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -50,7 +50,7 @@ Amendment orders → Changes to existing filings processed through the DB
 DNA Match Tag → Label indicating if Billing details agree with the DNA data
 Transaction table → Colored summary of Adyen transactions
 Light Gray Tag → Label color used for Adyen DNA entries in Review Mode (light gray background with black text)
-Knowledge Base window → Separate browser window that shows the Coda Knowledge Base next to the DB page
+Knowledge Base overlay → Floating window that shows the Coda Knowledge Base over the DB page
 
 AR COMPLETED         → Default comment used when resolving a Family Tree order
 Diagnose overlay → Floating panel listing Family Tree hold orders

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1829,17 +1829,29 @@
         input.addEventListener('keydown', e => { if (e.key === 'Enter') runSearch(); });
     }
 
-    // Opens the Coda knowledge base in a new window sized like a third column
+    // Opens the Coda knowledge base in a floating overlay covering 70% of the page
     function openKbOverlay(state, type) {
         const url = 'https://coda.io/d/Bizee-Filing-Department_dQJWsDF3UZ6/Knowledge-Base_suQao1ou';
-        const w = Math.round(window.screen.availWidth / 3);
-        const h = window.screen.availHeight;
-        const left = window.screen.availWidth - w;
-        const specs = `width=${w},height=${h},left=${left},top=0`;
-        const win = window.open(url, 'fennec_kb', specs);
-        if (!win) {
-            window.open(url, '_blank');
-        }
+        let backdrop = document.getElementById('fennec-kb-backdrop');
+        if (backdrop) backdrop.remove();
+        backdrop = document.createElement('div');
+        backdrop.id = 'fennec-kb-backdrop';
+        const overlay = document.createElement('div');
+        overlay.id = 'fennec-kb-overlay';
+        const close = document.createElement('div');
+        close.className = 'kb-close';
+        close.textContent = '✕';
+        close.addEventListener('click', () => backdrop.remove());
+        const frame = document.createElement('iframe');
+        frame.src = url;
+        frame.id = 'fennec-kb-frame';
+        overlay.appendChild(close);
+        overlay.appendChild(frame);
+        backdrop.appendChild(overlay);
+        document.body.appendChild(backdrop);
+        frame.addEventListener('load', () => {
+            chrome.runtime.sendMessage({ action: 'navigateKbFrame', state, orderType: type });
+        }, { once: true });
     }
 
     function getLastIssueInfo() {

--- a/FENNEC-main 31/manual-test.js
+++ b/FENNEC-main 31/manual-test.js
@@ -8,4 +8,4 @@ console.log("5. Verify the sidebar is absent on other sites.");
 console.log("6. Open the browser console and confirm there are no errors.");
 console.log("7. Click the company name or State ID in the DB sidebar and ensure it opens the state's SOS search page in a new tab.");
 console.log("8. Click the copy icon next to the company name and State ID and verify the text is copied to the clipboard without opening a link.");
-console.log("9. Click the state name and confirm a new window opens the filing department knowledge base next to the DB page.");
+console.log("9. Click the state name and confirm a floating window displays the filing department knowledge base over the DB page.");

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -629,8 +629,8 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 66%;
-    height: 66%;
+    width: 70%;
+    height: 70%;
     max-height: 90%;
     background: #2e2e2e;
     color: #f1f1f1;


### PR DESCRIPTION
## Summary
- show the Coda Knowledge Base as a large overlay instead of a side window
- navigate to the selected state in that overlay via injected script
- document overlay behavior in README, manual test guide and dictionary
- adjust CHANGELOG and sidebar styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b00efb7c8832696d0e97fc2b88a9d