### PR TITLE
Fix DNA label colors

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -91,5 +91,6 @@
 - Clicking the state in DB SB now opens the Coda Knowledge Base in a floating overlay covering most of the page.
 - Light gray labels now display black text in Light Mode.
 - Fixed light gray tags in Review Mode inheriting sidebar text color.
+- Refunded and cancelled totals now use a black **REFUNDED** tag and remain legible.
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use green for matches, purple for partial or no matches and black for unknown results.
 - Fixed Diagnose overlay comment box showing **null** instead of the current order number when triggered from the Family Tree panel.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -41,6 +41,7 @@ information scraped from the current page.
 - Light gray labels in Light Mode now keep black text for readability.
 - Adyen DNA labels use a light gray tag with black text in Review Mode.
 - The "Total" label in DNA transaction tables now uses the light gray tag.
+- Refund and cancel totals show a black tag labeled **REFUNDED**.
  - DNA pages open in front and focus returns to the original email tab after transactions load.
  - A CARD label under CVV and AVS compares DB card details with the Adyen card information and displays **DB: MATCH**, **DB: PARTIAL** or **DB: NO MATCH**.
 - A Refresh button updates information without reloading the page.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -837,6 +837,7 @@
                 "Authorised / Settled": "green",
                 "Settled": "green",
                 "Refused": "red",
+                "Refunded": "black",
                 "Chargebacks": "black",
                 "Chargeback": "black"
             };
@@ -849,8 +850,10 @@
 
             const entries = Object.keys(tx).map(k => {
                 const t = tx[k];
-                const label = k === "Authorised / Settled" ? "Settled" :
-                              k === "Total transactions" ? "Total" : k;
+                let label = k;
+                if (label === "Authorised / Settled") label = "Settled";
+                else if (label === "Total transactions") label = "Total";
+                else if (label === "Refunded / Cancelled") label = "Refunded";
                 return { label, count: t.count || "", amount: t.amount || "" };
             });
             if (!entries.length) return "";

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -326,6 +326,9 @@
     color: #000 !important;
     border: 1px solid #bbb;
 }
+.copilot-tag.tx-label {
+    color: #000 !important;
+}
 .copilot-tag-purple {
     background-color: #800080;
     color: #fff;

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -84,6 +84,9 @@
     color: #000 !important;
     border: 1px solid #777;
 }
+.fennec-light-mode #copilot-sidebar .copilot-tag.tx-label {
+    color: #000 !important;
+}
 
 .fennec-light-mode #fennec-diagnose-overlay .diag-order {
     color: #000;


### PR DESCRIPTION
## Summary
- override tx-label color for Adyen DNA table tags
- show REFUNDED totals in black
- update docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b10adaab08326ac4f33ee09b10a6d