### PR TITLE
Update REFUSED label color

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -42,6 +42,7 @@ information scraped from the current page.
 - Adyen DNA labels use a light gray tag with black text in Review Mode.
 - The "Total" label in DNA transaction tables now uses the light gray tag.
 - Refund and cancel totals show a black tag labeled **REFUNDED**.
+- REFUSED totals now use a purple tag instead of red.
  - DNA pages open in front and focus returns to the original email tab after transactions load.
  - A CARD label under CVV and AVS compares DB card details with the Adyen card information and displays **DB: MATCH**, **DB: PARTIAL** or **DB: NO MATCH**.
 - A Refresh button updates information without reloading the page.

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -836,7 +836,7 @@
                 "Total": "lightgray",
                 "Authorised / Settled": "green",
                 "Settled": "green",
-                "Refused": "red",
+                "Refused": "purple",
                 "Refunded": "black",
                 "Chargebacks": "black",
                 "Chargeback": "black"


### PR DESCRIPTION
## Summary
- make REFUSED transactions purple instead of red
- mention the new color in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b11b82164832681b3456d64ae4ba3