### PR TITLE
Ensure DNA labels remain black

### DIFF
--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -358,6 +358,9 @@
     text-align:center;
     color:#000 !important;
 }
+#copilot-sidebar .white-box .dna-label {
+    color: #000 !important;
+}
 .dna-count{
     font-weight:bold;
     font-size:11px;

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -59,6 +59,10 @@
     display: none;
 }
 
+#copilot-sidebar .white-box .dna-label {
+    color: #000 !important;
+}
+
 .fennec-light-mode #fennec-kb-overlay {
     background: #fff;
     color: #000 !important;


### PR DESCRIPTION
## Summary
- keep TOTAL tag text black by overriding inherited colors
- apply same rule for light theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b144cb7788326b4f102b6e9d46345