### PR TITLE
Add collapsible sidebar sections

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -46,6 +46,7 @@ information scraped from the current page.
  - DNA pages open in front and focus returns to the original email tab after transactions load.
  - A CARD label under CVV and AVS compares DB card details with the Adyen card information and displays **DB: MATCH**, **DB: PARTIAL** or **DB: NO MATCH**.
 - A Refresh button updates information without reloading the page.
+- Summary sections now have a –/+ **Summary Collapse Toggle** to quickly hide or show details.
  - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a floating overlay covering most of the page.

--- a/FENNEC-main 31/core/utils.js
+++ b/FENNEC-main 31/core/utils.js
@@ -1,5 +1,5 @@
 // Common utilities for FENNEC content scripts.
-// Provides escapeHtml and attachCommonListeners helpers.
+// Provides escapeHtml, attachCommonListeners and setupSectionToggles helpers.
 
 function escapeHtml(text) {
     return String(text)
@@ -189,5 +189,31 @@ function attachCommonListeners(rootEl) {
             });
         });
     }
+}
+
+function setupSectionToggles(rootEl) {
+    if (!rootEl) return;
+    rootEl.querySelectorAll('.order-summary-header, .section-label').forEach(h => {
+        if (h.classList.contains('toggle-ready')) return;
+        const target = h.nextElementSibling;
+        if (!target) return;
+        h.classList.add('toggle-ready');
+        const icon = document.createElement('span');
+        icon.className = 'collapse-toggle';
+        icon.textContent = '–';
+        h.appendChild(icon);
+        target.classList.add('collapsible');
+        target.style.maxHeight = target.scrollHeight + 'px';
+        icon.addEventListener('click', e => {
+            e.stopPropagation();
+            const collapsed = target.classList.toggle('collapsed');
+            icon.textContent = collapsed ? '+' : '–';
+            if (!collapsed) {
+                target.style.maxHeight = target.scrollHeight + 'px';
+            } else {
+                target.style.maxHeight = '0';
+            }
+        });
+    });
 }
 

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -59,3 +59,4 @@ Knowledge Base window → Separate browser window that shows the Coda Knowledge 
 AR COMPLETED         → Default comment used when resolving a Family Tree order
 Diagnose overlay → Floating panel listing Family Tree hold orders
 Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the current order number
+Summary Collapse Toggle → Icon used to collapse or expand summary sections

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -6,7 +6,6 @@
     });
     let currentOrderType = null;
     let currentOrderTypeText = null;
-    let initQuickSummary = null;
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
 
@@ -43,8 +42,8 @@
         chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null }, ({ sidebarDb, sidebarOrderId }) => {
             if (Array.isArray(sidebarDb) && sidebarDb.length && sidebarOrderId && sidebarOrderId === currentId) {
                 body.innerHTML = sidebarDb.join('');
-                if (typeof initQuickSummary === 'function') initQuickSummary();
                 attachCommonListeners(body);
+                setupSectionToggles(body);
                 updateReviewDisplay();
             } else {
                 body.innerHTML = '<div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>';
@@ -420,7 +419,7 @@
                             </div>
                             <button id="copilot-close">✕</button>
                         </div>
-                        <div class="order-summary-header"><span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span> ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
+                        <div class="order-summary-header"><span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span> ORDER SUMMARY</div>
                         <div class="copilot-body" id="copilot-body-content">
                             <div style="text-align:center; color:#888; margin-top:20px;">Cargando resumen...</div>
                             <div class="copilot-footer">
@@ -430,6 +429,7 @@
                         </div>
                     `;
                     document.body.appendChild(sidebar);
+                    setupSectionToggles(sidebar);
                     if (document.body.classList.contains('fennec-bento-mode')) {
                         const vid = document.createElement('video');
                         vid.id = 'bento-video';
@@ -478,28 +478,6 @@
                         } else {
                             extractAndShowFormationData();
                         }
-                    }
-                    const qsToggle = sidebar.querySelector('#qs-toggle');
-                    initQuickSummary = () => {
-                        const box = sidebar.querySelector('#quick-summary');
-                        if (box) {
-                            box.style.maxHeight = '0';
-                            box.classList.add('quick-summary-collapsed');
-                        }
-                    };
-                    initQuickSummary();
-                    if (qsToggle) {
-                        qsToggle.addEventListener('click', () => {
-                            const box = sidebar.querySelector('#quick-summary');
-                            if (!box) return;
-                            if (box.style.maxHeight && box.style.maxHeight !== '0px') {
-                                box.style.maxHeight = '0';
-                                box.classList.add('quick-summary-collapsed');
-                            } else {
-                                box.classList.remove('quick-summary-collapsed');
-                                box.style.maxHeight = box.scrollHeight + 'px';
-                            }
-                        });
                     }
 
                     const qaToggle = sidebar.querySelector('#qa-toggle');
@@ -1654,8 +1632,8 @@
         const body = document.getElementById('copilot-body-content');
         if (body) {
             body.innerHTML = html;
-            if (typeof initQuickSummary === 'function') initQuickSummary();
             attachCommonListeners(body);
+            setupSectionToggles(body);
             updateReviewDisplay();
         }
     }

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -1204,6 +1204,7 @@
                 </div>
             `;
             document.body.appendChild(sidebar);
+            setupSectionToggles(sidebar);
             if (document.body.classList.contains('fennec-bento-mode')) {
                 const vid = document.createElement('video');
                 vid.id = 'bento-video';

--- a/FENNEC-main 31/manual-test.js
+++ b/FENNEC-main 31/manual-test.js
@@ -9,3 +9,4 @@ console.log("6. Open the browser console and confirm there are no errors.");
 console.log("7. Click the company name or State ID in the DB sidebar and ensure it opens the state's SOS search page in a new tab.");
 console.log("8. Click the copy icon next to the company name and State ID and verify the text is copied to the clipboard without opening a link.");
 console.log("9. Click the state name and confirm a floating window displays the filing department knowledge base over the DB page.");
+console.log("10. Use the –/+ icon to collapse and expand a summary section.");

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -267,6 +267,12 @@
     margin-left: 6px;
     vertical-align: middle;
 }
+#copilot-sidebar .collapse-toggle {
+    cursor: pointer;
+    margin-left: 6px;
+    vertical-align: middle;
+    float: right;
+}
 #copilot-sidebar .family-tree-icon {
     cursor: pointer;
     margin-right: 6px;
@@ -288,6 +294,15 @@
 #copilot-sidebar #quick-summary.quick-summary-collapsed {
     margin-bottom: 0 !important;
     padding: 0 !important;
+}
+
+#copilot-sidebar .collapsible {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+#copilot-sidebar .collapsible.collapsed {
+    max-height: 0 !important;
 }
 
 /* Slightly larger names in each section */


### PR DESCRIPTION
## Summary
- add new `.collapse-toggle` and `.collapsible` CSS helpers
- implement `setupSectionToggles` to inject –/+ icons and animate collapsible sections
- remove old quick-summary toggle and apply the new helper in Gmail and DB
- document the **Summary Collapse Toggle** feature and update dictionary
- expand manual testing checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b154f7eb0832692a4e19bbec4b35e