### PR TITLE
Fix REFUNDED tag text color

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -92,5 +92,6 @@
 - Light gray labels now display black text in Light Mode.
 - Fixed light gray tags in Review Mode inheriting sidebar text color.
 - Refunded and cancelled totals now use a black **REFUNDED** tag and remain legible.
+- REFUNDED tag text is now white for better contrast.
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use green for matches, purple for partial or no matches and black for unknown results.
 - Fixed Diagnose overlay comment box showing **null** instead of the current order number when triggered from the Family Tree panel.

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -361,6 +361,9 @@
 #copilot-sidebar .white-box .dna-label {
     color: #000 !important;
 }
+#copilot-sidebar .dna-label.copilot-tag-black {
+    color: #fff !important;
+}
 .dna-count{
     font-weight:bold;
     font-size:11px;


### PR DESCRIPTION
## Summary
- make REFUNDED tag text white so it stays visible on black background
- log change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b15971c4c832697ec4f785fbf7be6