### PR TITLE
Fix refunded tag text color

### DIFF
--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -62,6 +62,9 @@
 #copilot-sidebar .white-box .dna-label {
     color: #000 !important;
 }
+#copilot-sidebar .white-box .dna-label.copilot-tag-black {
+    color: #fff !important;
+}
 
 .fennec-light-mode #fennec-kb-overlay {
     background: #fff;


### PR DESCRIPTION
## Summary
- ensure black tag uses white text in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1becd5ec8326827c232465fa4174