### PR TITLE
Update Gmail SB classic mode UI

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -46,7 +46,8 @@ information scraped from the current page.
  - DNA pages open in front and focus returns to the original email tab after transactions load.
  - A CARD label under CVV and AVS compares DB card details with the Adyen card information and displays **DB: MATCH**, **DB: PARTIAL** or **DB: NO MATCH**.
 - A Refresh button updates information without reloading the page.
- - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
+- Classic Mode now displays only the **SEARCH** button in the Gmail sidebar.
+- When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a popup window covering about 70% of the page.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -26,7 +26,7 @@ DB SB OFFICERS       → Officers section within DB SIDEBAR
 GM SB                → GMAIL SIDEBAR (visible during email inspection)
 GM SB REVIEW MODE    → GMAIL SIDEBAR when displaying full REVIEW MODE data
 GM SB XRAY     → The XRAY function/button/box inside the GMAIL SIDEBAR
-GM SB OPEN ORDER BUTTON     → The OPEN ORDER button inside the GMAIL SIDEBAR in Classic Mode.
+GM SB OPEN ORDER BUTTON     → [Deprecated] Former button in the GMAIL SIDEBAR used to open orders from Classic Mode.
 
 ────────────────────────────
 NOTES

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1505,7 +1505,6 @@
                 `<div><span class="${raClass}">RA: ${hasRA ? 'Sí' : 'No'}</span> ` +
                 `<span class="${vaClass}">VA: ${hasVA ? 'Sí' : 'No'}</span></div>`
             );
-            companyLines.push('<hr style="border:none; border-top:1px solid #eee; margin:6px 0"/>');
             const compSection = reviewMode
                 ? `
             <div class="white-box" style="margin-bottom:10px">

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -1179,21 +1179,19 @@
                     <button id="copilot-close">✕</button>
                 </div>
                 <div class="copilot-body">
-                    <div class="copilot-actions">
+                    <div class="copilot-actions" style="justify-content:center">
                         <button id="btn-email-search" class="copilot-button">📧 SEARCH</button>
-                        <button id="btn-open-order" class="copilot-button">📂 OPEN ORDER</button>
                     </div>
                     <div class="copilot-dna">
                         <div id="dna-summary" style="margin-top:16px"></div>
                     </div>
-                    <div class="section-label" style="margin:6px 0">COMPANY:</div>
-                    <div class="order-summary-header">ORDER SUMMARY</div>
                     <div class="order-summary-box">
                         <div id="order-summary-content" style="color:#ccc; font-size:13px;">
                             No order data yet.
                         </div>
                     </div>
                     <div id="db-summary-section"></div>
+                    <hr style="border:none;border-top:1px solid #555;margin:6px 0"/>
                     <div class="issue-summary-box" id="issue-summary-box" style="margin-top:10px;">
                         <strong>ISSUE <span id="issue-status-label" class="issue-status-label"></span></strong><br>
                         <div id="issue-summary-content" style="color:#ccc; font-size:13px; white-space:pre-line;">No issue data yet.</div>
@@ -1225,7 +1223,7 @@
             console.log("[Copilot] Sidebar INYECTADO en Gmail.");
 
             // Start with empty boxes. Details load after the user interacts
-            // with SEARCH or OPEN ORDER.
+            // with SEARCH.
 
             // Botón de cierre
             document.getElementById('copilot-close').onclick = () => {
@@ -1240,7 +1238,6 @@
             // Botón SEARCH (listener UNIFICADO)
             document.getElementById("btn-email-search").onclick = handleEmailSearchClick;
             document.getElementById("copilot-refresh").onclick = refreshSidebar;
-            setupOpenOrderButton();
             applyReviewMode();
             loadDnaSummary();
         }
@@ -1298,38 +1295,6 @@
             });
         }
 
-        function setupOpenOrderButton() {
-            const button = document.getElementById("btn-open-order");
-            if (!button) return;
-            button.addEventListener("click", function () {
-                try {
-                    showLoadingState();
-                    const bodyNode = document.querySelector(".a3s");
-                    if (!bodyNode) {
-                        alert("No se encontró el cuerpo del correo.");
-                        return;
-                    }
-
-                    const subjectText = document.querySelector('h2.hP')?.innerText || "";
-                    const text = subjectText + "\n" + (bodyNode.innerText || "");
-                    const orderId = extractOrderNumber(text);
-                    if (!orderId) {
-                        alert("No se encontró ningún número de orden válido en el correo.");
-                        return;
-                    }
-                    const context = extractOrderContextFromEmail();
-                    fillOrderSummaryBox(context);
-                    loadDbSummary(context && context.orderNumber);
-                    const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
-                    chrome.runtime.sendMessage({ action: "replaceTabs", urls: [url] });
-                    checkLastIssue(orderId);
-                } catch (error) {
-                    console.error("Error al intentar abrir la orden:", error);
-                    alert("Ocurrió un error al intentar abrir la orden.");
-                }
-            });
-        }
-
         function setupDnaButton() {
             const button = document.getElementById("btn-dna");
             if (!button || button.dataset.listenerAttached) return;
@@ -1372,12 +1337,6 @@
                 }, 500);
             });
         }
-
-        waitForElement("#btn-open-order").then(() => {
-            setupOpenOrderButton();
-        }).catch((err) => {
-            console.warn("[OPEN ORDER] No se pudo inyectar el listener:", err);
-        });
 
         waitForElement("#btn-dna").then(() => {
             setupDnaButton();

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -158,7 +158,7 @@
 }
 
 .issue-summary-box {
-    background-color: #2e2e2e;
+    background-color: #3a3a3a;
     color: #f1f1f1;
     padding: 8px;
     margin-top: 12px;


### PR DESCRIPTION
## Summary
- remove the `OPEN ORDER` button in Gmail classic mode and center the `SEARCH` button
- drop duplicate `COMPANY:` and `ORDER SUMMARY` headers
- add spacing before the Issues box and lighten its background
- remove extra rule after RA/VA labels in the DB summary
- document UI changes and mark the Open Order term deprecated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b24e6c7dc832681c9750d919d7220