### PR TITLE
Add clear tabs icon to sidebars

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -46,6 +46,7 @@ information scraped from the current page.
  - DNA pages open in front and focus returns to the original email tab after transactions load.
  - A CARD label under CVV and AVS compares DB card details with the Adyen card information and displays **DB: MATCH**, **DB: PARTIAL** or **DB: NO MATCH**.
 - A Refresh button updates information without reloading the page.
+- A Clear Tabs icon closes all other tabs in the current window.
 - DB sidebar formation orders now show a **FILING XRAY** button below the last section.
 - Classic Mode now displays only the **SEARCH** button in the Gmail sidebar.
 - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.

--- a/FENNEC-main 31/core/background_emailsearch.js
+++ b/FENNEC-main 31/core/background_emailsearch.js
@@ -81,6 +81,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
     }
 
+    if (message.action === "closeOtherTabs" && sender.tab) {
+        chrome.tabs.query({ windowId: sender.tab.windowId }, (tabs) => {
+            const toClose = tabs.filter(t => t.id !== sender.tab.id).map(t => t.id);
+            if (toClose.length) {
+                chrome.tabs.remove(toClose, () => {
+                    if (chrome.runtime.lastError) {
+                        console.error("[Copilot] Error cerrando pestañas:", chrome.runtime.lastError.message);
+                    }
+                });
+            }
+        });
+    }
+
     if (message.action === "checkLastIssue" && message.orderId) {
         const orderId = message.orderId;
         let base = "https://db.incfile.com";

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -60,3 +60,4 @@ Knowledge Base window → Popup covering about 70% of the DB page that shows the
 AR COMPLETED         → Default comment used when resolving a Family Tree order
 Diagnose overlay → Floating panel listing Family Tree hold orders
 Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the current order number
+Clear Tabs icon → Button that closes all other tabs in the window

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -418,6 +418,7 @@
                                 <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (v0.3)" />
                                 <span>FENNEC (v0.3)</span>
                             </div>
+                            <button id="copilot-clear-tabs">🗑</button>
                             <button id="copilot-close">✕</button>
                         </div>
                         <div class="order-summary-header"><span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span> ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
@@ -459,6 +460,13 @@
                             sessionStorage.setItem("fennecSidebarClosed", "true");
                             console.log("[Copilot] Sidebar cerrado manualmente en DB.");
                             showFloatingIcon();
+                        };
+                    }
+
+                    const clearBtn = sidebar.querySelector('#copilot-clear-tabs');
+                    if (clearBtn) {
+                        clearBtn.onclick = () => {
+                            chrome.runtime.sendMessage({ action: "closeOtherTabs" });
                         };
                     }
                     const isStorage = /\/storage\/incfile\//.test(location.pathname);

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -1172,10 +1172,12 @@
             sidebar.id = 'copilot-sidebar';
             sidebar.innerHTML = `
                 <div class="copilot-header">
+                    <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                     <div class="copilot-title">
                         <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (v0.3)" />
                         <span>FENNEC (v0.3)</span>
                     </div>
+                    <button id="copilot-clear-tabs">🗑</button>
                     <button id="copilot-close">✕</button>
                 </div>
                 <div class="copilot-body">
@@ -1234,6 +1236,13 @@
                 showFloatingIcon();
                 console.log("[Copilot] Sidebar cerrado manualmente en Gmail.");
             };
+
+            const clearBtn = document.getElementById('copilot-clear-tabs');
+            if (clearBtn) {
+                clearBtn.onclick = () => {
+                    chrome.runtime.sendMessage({ action: "closeOtherTabs" });
+                };
+            }
 
             // Botón SEARCH (listener UNIFICADO)
             document.getElementById("btn-email-search").onclick = handleEmailSearchClick;

--- a/FENNEC-main 31/styles/sidebar.css
+++ b/FENNEC-main 31/styles/sidebar.css
@@ -39,6 +39,15 @@
     cursor: pointer; outline: none;
     margin-left: 8px;
 }
+#copilot-clear-tabs {
+    background: none;
+    border: none;
+    color: #000;
+    font-size: 20px;
+    cursor: pointer;
+    outline: none;
+    margin-left: 8px;
+}
 .copilot-body {
     flex: 1;
     padding: 12px 18px;

--- a/FENNEC-main 31/styles/sidebar_light.css
+++ b/FENNEC-main 31/styles/sidebar_light.css
@@ -114,6 +114,9 @@
 .fennec-light-mode #copilot-close {
     color: #fff;
 }
+.fennec-light-mode #copilot-clear-tabs {
+    color: #fff;
+}
 
 /* Darken summary text that uses inline styles */
 .fennec-light-mode #order-summary-content,


### PR DESCRIPTION
## Summary
- add Clear Tabs button styles
- insert Clear Tabs button in DB and Gmail sidebars and expose menu icon on Gmail
- handle Clear Tabs action in background script
- document new feature in README and dictionary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b2a16a9048326bebdaa80ab00829b