### PR TITLE
Add formation date on misc orders

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -52,6 +52,7 @@ information scraped from the current page.
 - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a popup window covering about 70% of the page.
+- Non-formation sidebars show the Date of Formation beside the State ID.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the
   Coda doc ID. Generate a new token in Coda and replace the value after
   `Bearer` if searches return "No results". Set the doc ID without the leading

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1087,6 +1087,7 @@
         const companyRaw = extractSingle('#vcomp .form-body', [
             {name: 'name', label: 'company name'},
             {name: 'stateId', label: 'state id'},
+            {name: 'formationDate', label: 'date of formation'},
             {name: 'state', label: 'state of formation'},
             {name: 'status', label: 'state status'},
             {name: 'purpose', label: 'purpose'},
@@ -1132,6 +1133,7 @@
         const company = companyRaw ? {
             name: companyRaw.name,
             stateId: companyRaw.stateId,
+            formationDate: companyRaw.formationDate,
             state: companyRaw.state,
             status: companyRaw.status || headerStatus,
             purpose: companyRaw.purpose,
@@ -1504,7 +1506,10 @@
                 } else {
                     idHtml += ' ' + renderCopyIcon(company.stateId);
                 }
-                companyLines.push(`<div>${idHtml}</div>`);
+                const dof = currentOrderType !== 'formation' && company.formationDate
+                    ? ` (${escapeHtml(company.formationDate)})`
+                    : '';
+                companyLines.push(`<div>${idHtml}${dof}</div>`);
             }
             companyLines.push(`<div>${renderKb(company.state)}</div>`);
             companyLines.push(addrHtml);
@@ -1644,7 +1649,8 @@
             expedited: isExpeditedOrder(),
             companyName: company ? company.name : null,
             companyId: company ? company.stateId : null,
-            companyState: company ? company.state : null
+            companyState: company ? company.state : null,
+            formationDate: company ? company.formationDate : null
         };
         chrome.storage.local.set({
             sidebarDb: dbSections,

--- a/FENNEC-main 31/environments/gmail/gmail_launcher.js
+++ b/FENNEC-main 31/environments/gmail/gmail_launcher.js
@@ -688,7 +688,10 @@
                     const idBase = buildSosUrl(storedOrderInfo.companyState, null, 'id');
                     const compId = escapeHtml(storedOrderInfo.companyId);
                     const idLink = idBase ? `<a href="#" class="copilot-sos copilot-link" data-url="${idBase}" data-query="${compId}" data-type="id">${compId}</a>` : compId;
-                    html += `<div>${idLink} ${renderCopyIcon(storedOrderInfo.companyId)}</div>`;
+                    const dof = storedOrderInfo.type && storedOrderInfo.type.toLowerCase() !== 'formation' && storedOrderInfo.formationDate
+                        ? ` (${escapeHtml(storedOrderInfo.formationDate)})`
+                        : '';
+                    html += `<div>${idLink}${dof} ${renderCopyIcon(storedOrderInfo.companyId)}</div>`;
                 }
             }
             if (orderId) html += `<div><b><a href="#" id="order-link" class="order-link">${renderCopy(orderId)}</a> ${renderCopyIcon(orderId)}</b></div>`;


### PR DESCRIPTION
## Summary
- capture Date of Formation from DB order info
- display Date of Formation next to the State ID for non-formation orders
- pass formation date to Gmail sidebar
- document Date of Formation addition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c10afb2e08326995ef4412d03a97a