### PR TITLE
Extend TX SOS autofill

### DIFF
--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -48,7 +48,7 @@ information scraped from the current page.
 - A Refresh button updates information without reloading the page.
 - A Clear Tabs icon closes all other tabs in the current window.
 - DB sidebar formation orders now show a **🤖 FILE** button that opens a new window with the order and the Texas SOS page.
-- The FILE button now autofills the first Texas SOS pages, selecting entity type and entering the company name and mailing address.
+- The FILE button now autofills the Texas SOS pages. It logs in using the credentials saved in the Options page, selects entity type, enters the company name and mailing address, completes registered agent and member sections and signs with the organizer.
 - Classic Mode now displays only the **SEARCH** button in the Gmail sidebar.
 - When Review Mode is enabled a **🩻 XRAY** button runs **SEARCH** and then **DNA** automatically. The **OPEN ORDER** button is hidden. The **SEARCH**, **DNA** and **XRAY** buttons now share one row.
 - CODA Search menu item queries the knowledge base using the Coda API.

--- a/FENNEC-main 31/dictionary.txt
+++ b/FENNEC-main 31/dictionary.txt
@@ -63,3 +63,4 @@ Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLET
 Clear Tabs icon → Button that closes all other tabs in the window
 
 File Along → Opens a new window with TX SOS and guides formation filing automatically.
+Organizer → Person or entity that signs and submits the formation documents.

--- a/FENNEC-main 31/environments/db/db_launcher.js
+++ b/FENNEC-main 31/environments/db/db_launcher.js
@@ -1652,7 +1652,9 @@
             companyName: company ? company.name : null,
             companyId: company ? company.stateId : null,
             companyState: company ? company.state : null,
-            formationDate: company ? company.formationDate : null
+            formationDate: company ? company.formationDate : null,
+            registeredAgent: hasAgentInfo ? { name: agent.name, address: agent.address } : null,
+            members: directors
         };
         chrome.storage.local.set({
             sidebarDb: dbSections,

--- a/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
+++ b/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
@@ -2,6 +2,7 @@
 (function() {
     chrome.storage.local.get({ sidebarOrderInfo: null }, ({ sidebarOrderInfo }) => {
         const info = sidebarOrderInfo || {};
+        chrome.storage.sync.get({ txsosUser: "", txsosPass: "" }, creds => {
 
         function click(sel) {
             const el = document.querySelector(sel);
@@ -20,9 +21,11 @@
         const path = location.pathname;
 
         if (path.includes('/acct/acct-login.asp')) {
-            setValue('input[name="client_id"]', '66658900');
-            setValue('input[name="web_password"], input[name="password"]', 'Andr3sfue05$');
-            click('input[type="submit"]');
+            if (creds.txsosUser && creds.txsosPass) {
+                setValue('input[name="client_id"]', creds.txsosUser);
+                setValue('input[name="web_password"], input[name="password"]', creds.txsosPass);
+                click('input[type="submit"]');
+            }
             return;
         }
 
@@ -62,6 +65,88 @@
             setValue('input[name=":Sinitial_stateIA"]', 'TX');
             setValue('input[name=":Sinitial_zipIA"]', '77064');
             click('input[type="submit"][value="Continue"]');
+            return;
         }
+
+        if (document.querySelector('input[name=":Saddress1"]') && document.querySelector('input[name=":Szip_code"]')) {
+            const ra = info.registeredAgent || {};
+            if (ra.name) {
+                const parts = ra.name.trim().split(/\s+/);
+                setValue('input[name=":Sfirst_name"]', parts.shift() || '');
+                setValue('input[name=":Slast_name"]', parts.join(' '));
+            }
+            if (ra.address) {
+                const addr = ra.address.split(',');
+                setValue('input[name=":Saddress1"]', addr[0] || '');
+                if (addr[1]) {
+                    const cityState = addr[1].trim().split(/\s+/);
+                    setValue('input[name=":Scity"]', cityState[0] || '');
+                    if (cityState[1]) setValue('input[name=":Sstate"]', cityState[1].replace(/[^A-Z]/gi, '').slice(0,2));
+                    if (cityState[2]) setValue('input[name=":Szip_code"]', cityState[2]);
+                }
+            }
+            click('input[type="submit"][value="Continue"]');
+            return;
+        }
+
+        if (document.querySelector('input[name=":Nmanagement_type"]')) {
+            const radio = document.querySelector('input[name=":Nmanagement_type"][value="1"]');
+            if (radio) radio.checked = true;
+            const addBtn = document.querySelector('input[type="submit"][value="Add Manager/Member"]');
+            if (addBtn) { addBtn.click(); return; }
+        }
+
+        if (document.querySelector('input[name=":Scity"]') && document.querySelector('input[name=":NidxMO"]')) {
+            const idx = parseInt(document.querySelector('input[name=":NidxMO"]').value, 10) || 1;
+            const member = Array.isArray(info.members) ? info.members[idx - 1] : null;
+            if (member) {
+                const nameParts = (member.name || '').split(/\s+/);
+                setValue('input[name=":Sfirst_name"]', nameParts.shift() || '');
+                setValue('input[name=":Slast_name"]', nameParts.join(' '));
+                const addr = (member.address || '').split(',');
+                setValue('input[name=":Saddress1"]', addr[0] || '');
+                if (addr[1]) {
+                    const cs = addr[1].trim().split(/\s+/);
+                    setValue('input[name=":Scity"]', cs[0] || '');
+                    if (cs[1]) setValue('input[name=":Sstate"]', cs[1].replace(/[^A-Z]/gi, '').slice(0,2));
+                    if (cs[2]) setValue('input[name=":Szip_code"]', cs[2]);
+                }
+            }
+            const updBtn = document.querySelector('input[type="submit"][value="Update"]');
+            if (updBtn) { updBtn.click(); return; }
+        }
+
+        if (document.querySelector('input[type="submit"][value="Add Manager/Member"]')) {
+            const nextIdx = document.querySelectorAll('input[name=":NidxMO"]').length + 1;
+            if (info.members && info.members.length >= nextIdx) {
+                document.querySelector('input[type="submit"][value="Add Manager/Member"]').click();
+                return;
+            }
+            const cont = document.querySelector('input[type="submit"][value="Continue"]');
+            if (cont) { cont.click(); return; }
+        }
+
+        if (document.querySelector('input[name="page_caption"][value="Supplemental Provisions/Information"]')) {
+            const cont = document.querySelector('input[type="submit"][value="Continue"]');
+            if (cont) { cont.click(); return; }
+        }
+
+        if (document.querySelector('input[name="OA_desc"]')) {
+            setValue('input[name=":Slast_name"]', 'DOBSON');
+            setValue('input[name=":Sfirst_name"]', 'LOVETTE');
+            setValue('input[name=":Saddress1"]', '17350 State Hwy 249 Ste 220');
+            setValue('input[name=":Scity"]', 'Houston');
+            setValue('input[name=":Sstate"]', 'TX');
+            setValue('input[name=":Szip_code"]', '77064');
+            click('input[type="submit"][value="Continue"]');
+            return;
+        }
+
+        if (document.querySelector('input[name=":Sexecution1"]')) {
+            setValue('input[name=":Sexecution1"]', 'LOVETTE DOBSON');
+            const cont = document.querySelector('input[type="submit"][value="Continue"]');
+            if (cont) { cont.click(); return; }
+        }
+        });
     });
 })();

--- a/FENNEC-main 31/options.html
+++ b/FENNEC-main 31/options.html
@@ -16,6 +16,14 @@
         Sidebar width (px)
         <input type="number" id="sidebar-width" min="200" max="500" step="10">
     </label>
+    <label>
+        TX SOS User ID
+        <input type="text" id="txsos-user">
+    </label>
+    <label>
+        TX SOS Password
+        <input type="password" id="txsos-pass">
+    </label>
     <button id="save-btn" style="margin-top:10px;">Save</button>
     <script src="options.js"></script>
 </body>

--- a/FENNEC-main 31/options.js
+++ b/FENNEC-main 31/options.js
@@ -3,11 +3,15 @@
 document.addEventListener("DOMContentLoaded", () => {
     const reviewBox = document.getElementById("default-review");
     const widthInput = document.getElementById("sidebar-width");
+    const userInput = document.getElementById("txsos-user");
+    const passInput = document.getElementById("txsos-pass");
     const saveBtn = document.getElementById("save-btn");
 
-    chrome.storage.sync.get({ defaultReviewMode: false, sidebarWidth: 340 }, (opts) => {
+    chrome.storage.sync.get({ defaultReviewMode: false, sidebarWidth: 340, txsosUser: "", txsosPass: "" }, (opts) => {
         reviewBox.checked = Boolean(opts.defaultReviewMode);
         widthInput.value = parseInt(opts.sidebarWidth, 10) || 340;
+        userInput.value = opts.txsosUser || "";
+        passInput.value = opts.txsosPass || "";
     });
 
     function save() {
@@ -15,6 +19,8 @@ document.addEventListener("DOMContentLoaded", () => {
         chrome.storage.sync.set({
             defaultReviewMode: reviewBox.checked,
             sidebarWidth: width,
+            txsosUser: userInput.value,
+            txsosPass: passInput.value,
             fennecReviewMode: reviewBox.checked
         });
         chrome.storage.local.set({ fennecReviewMode: reviewBox.checked });


### PR DESCRIPTION
## Summary
- store Texas SOS user credentials in the Options page
- keep registered agent and member info in `sidebarOrderInfo`
- extend the TX SOS automation script to complete RA, member and organizer pages
- document the updated behaviour and add `Organizer` to the glossary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3290ed208326a738f5465cabe203