### PR TITLE
Fix TX SOS login detection for File Along

### DIFF
--- a/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
+++ b/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
@@ -95,7 +95,7 @@
         function performSteps() {
             const path = location.pathname;
 
-            if (path.includes('/acct/acct-login.asp')) {
+            if (path.includes('/acct/acct-login.asp') && document.querySelector('input[name="client_id"]')) {
                 log('Login page');
                 if (creds.txsosUser && creds.txsosPass) {
                     log('Filling credentials');


### PR DESCRIPTION
## Summary
- ensure the File Along automation only runs login logic when the login fields are present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4f4a02888326a6a4773011e2dd05