### PR TITLE
Fix payment type check

### DIFF
--- a/FENNEC-main 31/CHANGELOG.md
+++ b/FENNEC-main 31/CHANGELOG.md
@@ -96,3 +96,4 @@
  - EMAIL SEARCH button renamed to **SEARCH**. In Review Mode the **SEARCH**, **DNA** and **XRAY** buttons appear on the same line. The DB match tag in DNA now shows below the CVV/AVS labels and those labels use green for matches, purple for partial or no matches and black for unknown results.
 - Fixed Diagnose overlay comment box showing **null** instead of the current order number when triggered from the Family Tree panel.
 - Payment fields inside nested iframes are now detected so File Along selects the Client Account option reliably.
+- The payment step now verifies **Client Account** is selected before continuing.

--- a/FENNEC-main 31/README.md
+++ b/FENNEC-main 31/README.md
@@ -53,7 +53,7 @@ information scraped from the current page.
 - Texas SOS pages opened through File Along display the FENNEC sidebar with your current order summaries while the script steps through all fourteen filing screens automatically.
 - Console logs now show each File Along step for easier troubleshooting.
 - File Along retries each step for up to fifty seconds to handle slow page loads.
-- Step 2 sets the payment method to **Client Account** before continuing.
+ - The script chooses **Client Account** on the payment screen before continuing.
 - File Along now detects form fields inside iframes so the payment step works
   reliably after login.
 - Field lookups now search nested iframes so the payment dropdown is always

--- a/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
+++ b/FENNEC-main 31/environments/txsos/tx_sos_launcher.js
@@ -130,6 +130,9 @@
                 const sel = query('select[name="payment_type_id"]');
                 const opt = Array.from(sel.options).find(o => /client account/i.test(o.textContent));
                 setValue('select[name="payment_type_id"]', opt ? opt.value : '5');
+                if (sel.value !== '5') {
+                    return false;
+                }
                 click('input[type="submit"][value="Continue"]');
                 return true;
             }


### PR DESCRIPTION
## Summary
- retry File Along payment step until the Client Account option sticks
- describe how Client Account is chosen in the documentation
- document the retry behavior in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6fe747b48326811f3958c26de130