### PR TITLE
Fix form submission

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The payment step logs the dropdown selector and value before clicking **Continue** so you can confirm **Client Account** is selected.
+- Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -369,7 +369,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                                     if (btn) {
                                         btn.click();
                                     } else if (form) {
-                                        form.submit();
+                                        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
                                     } else {
                                         field.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
                                         field.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", bubbles: true }));


### PR DESCRIPTION
## Summary
- avoid calling `form.submit()` when running searches
- document new behavior in `CHANGELOG`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c7e7b7a388326bfa0e29b9098ab45