### PR TITLE
Improve TX SOS File Along logging

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -64,6 +64,8 @@ information scraped from the current page.
   found.
 - Fixed a field lookup bug that caused an endless loop, allowing the login and
   payment steps to complete successfully.
+ - Timeouts waiting for form fields now log a warning so you can see exactly
+   where File Along stops.
 - File Along no longer prompts for permission to access `direct.sos.state.tx.us`.
 - `tx_sos_launcher.js` now uses Puppeteer to test Client Account selection with the sample page `TX_BF_LLC_1.html`.
 - `tx_sos_puppeteer.js` automates the full Texas SOS filing process with Puppeteer.

--- a/FENNEC/environments/txsos/tx_sos_launcher.js
+++ b/FENNEC/environments/txsos/tx_sos_launcher.js
@@ -33,13 +33,16 @@
             }
 
             function waitFor(selector, timeout = 50000) {
+                console.log("[FENNEC TXSOS] Waiting for", selector);
                 return new Promise(resolve => {
                     const start = Date.now();
                     (function check() {
                         const el = findElement(selector);
                         if (el) {
+                            console.log("[FENNEC TXSOS] Found", selector);
                             resolve(el);
                         } else if (Date.now() - start >= timeout) {
+                            console.warn("[FENNEC TXSOS] Timeout waiting for", selector);
                             resolve(null);
                         } else {
                             setTimeout(check, 500);


### PR DESCRIPTION
## Summary
- log when waiting for TX SOS elements so timeouts are visible
- note timeout logging in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ca610b1848326bf0c16d05ea989b4