### PR TITLE
Improve TX SOS login fallback

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -64,6 +64,10 @@ information scraped from the current page.
   found.
 - Fixed a field lookup bug that caused an endless loop, allowing the login and
   payment steps to complete successfully.
+- Timeouts waiting for form fields now log a warning so you can see exactly
+  where File Along stops.
+- If the login submit button can't be located, File Along now submits the form
+  directly.
 - File Along no longer prompts for permission to access `direct.sos.state.tx.us`.
 - `tx_sos_launcher.js` now uses Puppeteer to test Client Account selection with the sample page `TX_BF_LLC_1.html`.
 - `tx_sos_puppeteer.js` automates the full Texas SOS filing process with Puppeteer.

--- a/FENNEC/environments/txsos/tx_sos_launcher.js
+++ b/FENNEC/environments/txsos/tx_sos_launcher.js
@@ -33,13 +33,16 @@
             }
 
             function waitFor(selector, timeout = 50000) {
+                console.log("[FENNEC TXSOS] Waiting for", selector);
                 return new Promise(resolve => {
                     const start = Date.now();
                     (function check() {
                         const el = findElement(selector);
                         if (el) {
+                            console.log("[FENNEC TXSOS] Found", selector);
                             resolve(el);
                         } else if (Date.now() - start >= timeout) {
+                            console.warn("[FENNEC TXSOS] Timeout waiting for", selector);
                             resolve(null);
                         } else {
                             setTimeout(check, 500);
@@ -57,7 +60,7 @@
                 Promise.all([
                     waitFor("input[name='client_id']"),
                     waitFor("input[name='web_password']"),
-                    waitFor("input[type='submit'][name='submit'], input[type='submit'][value='Submit']")
+                    waitFor("input[name='submit'], input[type='submit'], button[type='submit']")
                 ]).then(([userInput, passInput, button]) => {
                     try {
                         if (userInput) {
@@ -71,8 +74,16 @@
                             passInput.dispatchEvent(new Event("input", { bubbles: true }));
                         }
                         if (button && userInput && passInput) {
-                            console.log("[FENNEC TXSOS] Submitting login");
+                            console.log("[FENNEC TXSOS] Submitting login via button");
                             setTimeout(() => button.click(), 300);
+                        } else if (userInput && passInput) {
+                            const form = userInput.closest("form");
+                            if (form) {
+                                console.warn("[FENNEC TXSOS] Button missing; submitting form directly");
+                                setTimeout(() => form.submit(), 300);
+                            } else {
+                                console.error("[FENNEC TXSOS] No login form found");
+                            }
                         }
                     } catch (err) {
                         console.error("[FENNEC TXSOS] Login error", err);


### PR DESCRIPTION
## Summary
- add fallback to submit the login form directly when the TX SOS submit button can't be found
- extend logging selector for the login button
- document the new fallback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca610b1848326bf0c16d05ea989b4