### PR TITLE
Fix Mistral chat box removal

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The payment step logs the dropdown selector and value before clicking **Continue** so you can confirm **Client Account** is selected.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
+- Fixed the Mistral chat box disappearing after loading the order summary.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1651,6 +1651,16 @@
             html = `<div style="text-align:center; color:#aaa; margin-top:40px">No se encontró información relevante de la orden.</div>`;
         }
         html += `<div class="copilot-footer"><button id="filing-xray" class="copilot-button">🤖 FILE</button></div>`;
+        html += `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>`;
+        html += `
+        <div id="mistral-chat" class="mistral-box">
+            <div id="mistral-log" class="mistral-log"></div>
+            <div class="mistral-input-row">
+                <input id="mistral-input" type="text" placeholder="Ask Mistral..." />
+                <button id="mistral-send" class="copilot-button">Send</button>
+            </div>
+        </div>
+        <div id="review-mode-label" class="review-mode-label" style="display:none; margin-top:4px; text-align:center; font-size:11px;">REVIEW MODE</div>`;
 
         const orderInfo = getBasicOrderInfo();
         const sidebarOrderInfo = {
@@ -1675,6 +1685,7 @@
             body.innerHTML = html;
             if (typeof initQuickSummary === 'function') initQuickSummary();
             attachCommonListeners(body);
+            initMistralChat();
             updateReviewDisplay();
         }
     }


### PR DESCRIPTION
## Summary
- keep Mistral chat markup when rendering the DB sidebar
- re-initialize the chat after updating the sidebar
- note the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebeb701708326ba8af5761e78e450