### PR TITLE
Connect extension to local Mistral

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
 - Fixed the Mistral chat box disappearing after loading the order summary.
+- The Mistral Box now sends prompts to a local Ollama server at
+  `http://localhost:11434/api/generate`.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -128,6 +128,11 @@ GENERAL FEATURES:
 5. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode.
 
 
+## Local Mistral integration
+The Mistral Box sends prompts to a local [Ollama](https://ollama.ai) server.
+Start Ollama so the API is reachable at `http://localhost:11434/api/generate`.
+Responses from that endpoint appear below the REFRESH button.
+
 ## Development
 
 This repository now includes a minimal `package.json` to simplify future testing and build automation. The `npm test` command prints manual testing steps.

--- a/FENNEC/core/mistral_chat.js
+++ b/FENNEC/core/mistral_chat.js
@@ -1,9 +1,19 @@
-// Chat UI and Mistral placeholder integration for FENNEC.
-// Provides a simple chat interface using the local Mistral model if available.
+// Chat UI and Mistral integration for FENNEC.
+// Provides a simple chat interface using a local Mistral model if available.
 
 function sendToMistral(prompt) {
-    // Placeholder for local model inference. Replace with actual model call.
-    return Promise.resolve("Mistral model not available.");
+    const body = {
+        model: "mistral",
+        prompt,
+        stream: false
+    };
+    return fetch("http://localhost:11434/api/generate", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(body)
+    })
+        .then(r => r.json())
+        .then(j => j.response || "");
 }
 
 function initMistralChat() {

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -69,3 +69,4 @@ Puppeteer → Node.js library for automated browser control
 TX SOS Puppeteer script → Node script that automates the full Texas formation filing.
 Mistral → Local AI model used for chat guidance
 Mistral Box → Chat area below REFRESH button
+Ollama → Local server running the Mistral API

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -16,7 +16,8 @@
         "https://tools.usps.com/*",
         "https://coda.io/*",
         "https://ca-live.adyen.com/*",
-        "https://direct.sos.state.tx.us/*"
+        "https://direct.sos.state.tx.us/*",
+        "http://localhost:11434/*"
     ],
   "optional_host_permissions": [
     "https://*/*"


### PR DESCRIPTION
## Summary
- enable calls to local Ollama server in `sendToMistral`
- allow requests to http://localhost:11434 in the manifest
- document how to start and use the local Mistral server
- add Ollama to the dictionary
- note the new feature in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec0ffc61083268a3a30c6a0d50508