### PR TITLE
Fix CORS error for local Mistral

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -12,6 +12,8 @@
   communicating with the local server.
 - Friendly error message now appears if the Mistral service is unavailable and
   includes a **Retry** button.
+- The background script strips the `Origin` header so the local server accepts
+  Mistral requests without returning **403**.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -133,6 +133,8 @@ The Mistral Box sends prompts to a local [Ollama](https://ollama.ai) server.
 Start Ollama so the API is reachable at `http://127.0.0.1:11434/api/generate`.
 Responses from that endpoint appear below the REFRESH button.
 The requests are sent through the background script so CORS errors do not occur.
+The extension removes the `Origin` header from these requests so Ollama accepts
+them without additional configuration.
 If the chat displays **Mistral service unavailable. Ensure Ollama is running.**
 start or restart Ollama and click **Retry** in the chat box.
 

--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -1,4 +1,15 @@
 // Background worker handling tab management and other extension messages
+// Strip the Origin header when contacting the local Mistral API to avoid
+// 403 responses from Ollama's CORS checks.
+chrome.webRequest.onBeforeSendHeaders.addListener(
+    details => {
+        const headers = details.requestHeaders.filter(h => h.name.toLowerCase() !== "origin");
+        return { requestHeaders: headers };
+    },
+    { urls: ["http://127.0.0.1:11434/*"] },
+    ["blocking", "requestHeaders"]
+);
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "openTab" && message.url) {
         console.log("[Copilot] Forzando apertura de una pestaña:", message.url);

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -7,7 +7,9 @@
     "storage",
     "activeTab",
     "scripting",
-    "tabs"
+    "tabs",
+    "webRequest",
+    "webRequestBlocking"
   ],
     "host_permissions": [
         "https://mail.google.com/*",


### PR DESCRIPTION
## Summary
- intercept requests to the local Mistral server and remove the `Origin` header
- allow the service worker to use the webRequest API
- document the header removal
- note the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685edf7343c083269015a34089f6fd7f