### PR TITLE
Fix Mistral request handling

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -132,9 +132,9 @@ GENERAL FEATURES:
 The Mistral Box sends prompts to a local [Ollama](https://ollama.ai) server.
 Start Ollama so the API is reachable at `http://127.0.0.1:11434/api/generate`.
 Responses from that endpoint appear below the REFRESH button.
-The requests are sent through the background script so CORS errors do not occur.
-The extension removes the `Origin` header from these requests so Ollama accepts
-them without additional configuration.
+Requests are sent through the background script, which installs a
+declarative rule to remove the `Origin` header so Ollama accepts them
+without triggering CORS errors.
 If the chat displays **Mistral service unavailable. Ensure Ollama is running.**
 start or restart Ollama and click **Retry** in the chat box.
 

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -8,8 +8,7 @@
     "activeTab",
     "scripting",
     "tabs",
-    "webRequest",
-    "webRequestBlocking"
+    "declarativeNetRequest"
   ],
     "host_permissions": [
         "https://mail.google.com/*",


### PR DESCRIPTION
## Summary
- drop `webRequest` permissions
- use `chrome.declarativeNetRequest` to remove Origin header
- document the new rule in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee60f57d88326a27efe24cce86a67