### PR TITLE
Fix diagnose child order limit

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -14,6 +14,7 @@
   includes a **Retry** button.
 - The background script strips the `Origin` header so the local server accepts
   Mistral requests without returning **403**.
+- Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 
 ## v0.3 - 2025-06-24

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -117,6 +117,7 @@ ICONS/BUTTONS/FUNCTIONS:
 GENERAL FEATURES:
 - Clicking COMPANY NAME opens the SOS search.
 - Clicking the STATE ID in the sidebar opens the Coda Knowledge Base in a popup window covering about 70% of the page.
+- 🩺 DIAGNOSE overlay lists hold orders from the Family Tree and now displays all child orders.
 
 ## Known limitations
 - The scripts rely on the browser DOM provided by Chrome.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1968,7 +1968,7 @@
             const db = Date.parse(b.date);
             return (isNaN(db) ? 0 : db) - (isNaN(da) ? 0 : da);
         });
-        return info.slice(0, 3);
+        return info;
     }
 
     function getBasicOrderInfo() {


### PR DESCRIPTION
## Summary
- remove 3-item cap when reading child orders
- document Diagnose overlay change in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862cf9aa1348326b0589d80173971cc