### PR TITLE
Ensure Review Mode sidebar stays locked

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -110,6 +110,7 @@ ICONS/BUTTONS/FUNCTIONS:
    2. DNA
 
    Focus returns to the original email once information is retrieved.
+   In Review Mode the sidebar stays locked to the email view across all tabs until DNA runs on a different order.
 🩻 XRAY: Runs SEARCH and DNA operations one after the other.
    Focus also returns to the original email at the end.
 🤖 FILE: Automator that opens and fills the SOS filing process.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -478,23 +478,27 @@
                         };
                     }
                     const isStorage = /\/storage\/incfile\//.test(location.pathname);
-                    if (isStorage) {
-                        loadStoredSummary();
-                    } else {
-                        const orderType = getOrderType();
-                        currentOrderType = orderType;
-                        const rawType = getText(document.getElementById('ordType')) || '';
-                        currentOrderTypeText = normalizeOrderType(rawType);
-                        const ftIcon = sidebar.querySelector('#family-tree-icon');
-                        if (ftIcon) {
-                            ftIcon.style.display = orderType !== 'formation' ? 'inline' : 'none';
-                        }
-                        if (orderType === "amendment") {
-                            extractAndShowAmendmentData();
+                    chrome.storage.local.get({ sidebarFreezeId: null }, ({ sidebarFreezeId }) => {
+                        const currentId = getBasicOrderInfo().orderId;
+                        const frozen = sidebarFreezeId && sidebarFreezeId === currentId;
+                        if (isStorage || frozen) {
+                            loadStoredSummary();
                         } else {
-                            extractAndShowFormationData();
+                            const orderType = getOrderType();
+                            currentOrderType = orderType;
+                            const rawType = getText(document.getElementById('ordType')) || '';
+                            currentOrderTypeText = normalizeOrderType(rawType);
+                            const ftIcon = sidebar.querySelector('#family-tree-icon');
+                            if (ftIcon) {
+                                ftIcon.style.display = orderType !== 'formation' ? 'inline' : 'none';
+                            }
+                            if (orderType === "amendment") {
+                                extractAndShowAmendmentData();
+                            } else {
+                                extractAndShowFormationData();
+                            }
                         }
-                    }
+                    });
                     const qsToggle = sidebar.querySelector('#qs-toggle');
                     initQuickSummary = () => {
                         const box = sidebar.querySelector('#quick-summary');

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1332,7 +1332,9 @@
                     console.log('[Copilot] Opening Adyen for order', orderId);
                     const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
                     showDnaLoading();
-                    chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
+                    chrome.storage.local.set({ sidebarFreezeId: orderId }, () => {
+                        chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
+                    });
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");


### PR DESCRIPTION
## Summary
- capture order id when DNA button is used
- skip DB extraction while the stored ID matches the current page
- note the new Review Mode behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862eadeedac83269d571abe0d7474af