### PR TITLE
Add Adyen sidebar and improve DNA button

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -90,6 +90,8 @@ MISC:
       4th box: BILLING summary
       5th box: Issue summary
       (Dev Mode) End: [🔄 REFRESH] button centered.
+   ADYEN:
+      Sidebar shows the DB summary and DNA results after XRAY.
 
 DEV MODE:
 New experimental mode where upcoming features are tested before release.

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1329,12 +1329,21 @@
                         alert("No se encontró ningún número de orden válido en el correo.");
                         return;
                     }
-                    console.log('[Copilot] Opening Adyen for order', orderId);
-                    const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
-                    showDnaLoading();
-                    chrome.storage.local.set({ sidebarFreezeId: orderId }, () => {
-                        chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
-                    });
+                    function openAdyen() {
+                        console.log('[Copilot] Opening Adyen for order', orderId);
+                        const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
+                        showDnaLoading();
+                        chrome.storage.local.set({ sidebarFreezeId: orderId }, () => {
+                            chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
+                        });
+                    }
+
+                    if (!storedOrderInfo || storedOrderInfo.orderId !== orderId) {
+                        handleEmailSearchClick();
+                        setTimeout(openAdyen, 500);
+                    } else {
+                        openAdyen();
+                    }
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -68,8 +68,15 @@
       "matches": [
         "https://ca-live.adyen.com/*"
       ],
+      "all_frames": true,
       "js": [
+        "core/utils.js",
         "environments/adyen/adyen_launcher.js"
+      ],
+      "css": [
+        "styles/sidebar.css",
+        "styles/sidebar_light.css",
+        "styles/sidebar_bento.css"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- extend DNA button to load DB data automatically
- inject sidebar on Adyen pages and load stored info
- include sidebar resources for Adyen in the manifest
- document Adyen sidebar in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f1b26884832683a37a342eae7b3c