### PR TITLE
Fix DB extraction in review mode

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed popup Review Mode toggle to use sync storage so the DNA button appears after enabling the mode.
 - Fixed DNA button not appearing in Gmail Review Mode by storing the setting locally.
 - Fixed the DNA summary replacing the button in Gmail Review Mode so the button remains visible when no data is available.
+- DB sidebar now extracts information when first locked by DNA so Gmail Review Mode shows the full summary.
 - Escaped quotes in the background script so the service worker loads correctly.
   Buttons like **EMAIL SEARCH** and **OPEN ORDER** now open tabs again.
 - Common helpers moved to `core/utils.js` and shared by Gmail and DB scripts.

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -74,3 +74,4 @@ Ollama → Local server running the Mistral API
 Retry button → Resends a prompt when the Mistral service is unavailable
 BOIR → Beneficial Ownership Information Report
 BETA → Early test version of Fennec
+Sidebar freeze → Mechanism locking sidebar data to the last processed order until XRAY runs again

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -478,10 +478,11 @@
                         };
                     }
                     const isStorage = /\/storage\/incfile\//.test(location.pathname);
-                    chrome.storage.local.get({ sidebarFreezeId: null }, ({ sidebarFreezeId }) => {
+                    chrome.storage.local.get({ sidebarFreezeId: null, sidebarDb: [], sidebarOrderId: null }, ({ sidebarFreezeId, sidebarDb, sidebarOrderId }) => {
                         const currentId = getBasicOrderInfo().orderId;
                         const frozen = sidebarFreezeId && sidebarFreezeId === currentId;
-                        if (isStorage || frozen) {
+                        const hasStored = Array.isArray(sidebarDb) && sidebarDb.length && sidebarOrderId === currentId;
+                        if (isStorage || (frozen && hasStored)) {
                             loadStoredSummary();
                         } else {
                             const orderType = getOrderType();


### PR DESCRIPTION
## Summary
- ensure DB extraction runs when DNA first locks the sidebar
- document sidebar freeze term
- note fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f4ca16848326938def4bb88f3c06