### PR TITLE
Fix DNA reset when using XRAY

### DIFF
--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -37,7 +37,11 @@
             let currentContext = null;
             let storedOrderInfo = null;
             if (!sessionStorage.getItem('fennecDnaCleared')) {
-                chrome.storage.local.set({ adyenDnaInfo: null });
+                chrome.storage.local.get({ sidebarFreezeId: null }, ({ sidebarFreezeId }) => {
+                    if (!sidebarFreezeId) {
+                        chrome.storage.local.set({ adyenDnaInfo: null });
+                    }
+                });
                 sessionStorage.setItem('fennecDnaCleared', '1');
             }
 


### PR DESCRIPTION
## Summary
- prevent new Gmail tabs from wiping DNA info while XRAY runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686302679eec8326a29ef89463ca99f3