### PR TITLE
Add sidebar clear button

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -108,6 +108,7 @@ ICONS/BUTTONS/FUNCTIONS:
    1. Gmail Search with Order Number, Customer Email, Customer Name. 
    2. Order in DB
 🗑 CLEAR TABS: Closes all tabs, except the one active, in current window.
+🧹 CLEAR: Resets the sidebar to its initial empty state.
 🔄 Refresh: Updates sidebar information instantly with information extracted from the active tab.
 🧬 DNA: Opens order payment information in Adyen and extracts relevant information from two tabs:
    1. Payment Details

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -62,6 +62,7 @@ AR COMPLETED         → Default comment used when resolving a Family Tree order
 Diagnose overlay → Floating panel listing Family Tree hold orders
 Comment Box → Editable field in the diagnose overlay prefilled with AR COMPLETED and the current order number
 Clear Tabs icon → Button that closes all other tabs in the window
+Clear SB button → Removes sidebar content and resets it to its initial state
 
 File Along → Opens a new window with TX SOS and guides formation filing automatically.
 Organizer → Person or entity that signs and submits the formation documents.

--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -299,6 +299,20 @@
                 });
             }
 
+            function clearSidebar() {
+                chrome.storage.local.set({
+                    sidebarDb: [],
+                    sidebarOrderId: null,
+                    sidebarOrderInfo: null,
+                    adyenDnaInfo: null,
+                    sidebarFreezeId: null
+                });
+                const db = document.getElementById('db-summary-section');
+                if (db) db.innerHTML = '<div style="text-align:center; color:#aaa; font-size:13px;">No DB data.</div>';
+                const dna = document.getElementById('dna-summary');
+                if (dna) dna.innerHTML = '';
+            }
+
             function injectSidebar() {
                 if (document.getElementById('copilot-sidebar')) return;
                 const sidebar = document.createElement('div');
@@ -316,6 +330,7 @@
                             <div id="dna-summary" style="margin-top:16px"></div>
                         </div>
                         <div id="db-summary-section"></div>
+                        <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                     </div>`;
                 document.body.appendChild(sidebar);
                 document.body.style.marginRight = '340px';
@@ -326,6 +341,8 @@
                         document.body.style.marginRight = '';
                     };
                 }
+                const clearSb = sidebar.querySelector('#copilot-clear');
+                if (clearSb) clearSb.onclick = clearSidebar;
                 loadDbSummary();
                 loadDnaSummary();
             }

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -430,6 +430,7 @@
                             </div>
                             <div style="text-align:center; color:#888; margin-top:20px;">Cargando resumen...</div>
                             ${devMode ? `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>` : ``}
+                            <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                             ${devMode ? `
                             <div id="mistral-chat" class="mistral-box">
                                 <div id="mistral-log" class="mistral-log"></div>
@@ -480,6 +481,8 @@
                             chrome.runtime.sendMessage({ action: "closeOtherTabs" });
                         };
                     }
+                    const clearSb = sidebar.querySelector('#copilot-clear');
+                    if (clearSb) clearSb.onclick = clearSidebar;
                     const isStorage = /\/storage\/incfile\//.test(location.pathname);
                     chrome.storage.local.get({ sidebarFreezeId: null, sidebarDb: [], sidebarOrderId: null }, ({ sidebarFreezeId, sidebarDb, sidebarOrderId }) => {
                         const currentId = getBasicOrderInfo().orderId;
@@ -1881,6 +1884,21 @@
             container.innerHTML = html || '';
             attachCommonListeners(container);
         });
+    }
+
+    function clearSidebar() {
+        chrome.storage.local.set({
+            sidebarDb: [],
+            sidebarOrderId: null,
+            sidebarOrderInfo: null,
+            adyenDnaInfo: null,
+            sidebarFreezeId: null
+        });
+        const body = document.getElementById('copilot-body-content');
+        if (body) body.innerHTML = '<div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>';
+        const dnaContainer = document.getElementById('dna-summary');
+        if (dnaContainer) dnaContainer.innerHTML = '';
+        updateReviewDisplay();
     }
 
     function getBillingInfo() {

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1137,6 +1137,32 @@
             loadDnaSummary();
         }
 
+        function clearSidebar() {
+            storedOrderInfo = null;
+            currentContext = null;
+            chrome.storage.local.set({
+                sidebarDb: [],
+                sidebarOrderId: null,
+                sidebarOrderInfo: null,
+                adyenDnaInfo: null,
+                sidebarFreezeId: null
+            });
+            const orderBox = document.getElementById('order-summary-content');
+            if (orderBox) orderBox.innerHTML = 'No order data yet.';
+            const dbBox = document.getElementById('db-summary-section');
+            if (dbBox) dbBox.innerHTML = '<div style="text-align:center; color:#aaa; font-size:13px;">No DB data.</div>';
+            const issueContent = document.getElementById('issue-summary-content');
+            if (issueContent) issueContent.innerHTML = 'No issue data yet.';
+            const issueLabel = document.getElementById('issue-status-label');
+            if (issueLabel) {
+                issueLabel.textContent = '';
+                issueLabel.className = 'issue-status-label';
+            }
+            loadDnaSummary();
+            repositionDnaSummary();
+            applyReviewMode();
+        }
+
         function handleEmailSearchClick() {
             showLoadingState();
 
@@ -1212,6 +1238,7 @@
                         <div id="issue-summary-content" style="color:#ccc; font-size:13px; white-space:pre-line;">No issue data yet.</div>
                     </div>
                     ${devMode ? `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>` : ``}
+                    <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                 </div>
             `;
             document.body.appendChild(sidebar);
@@ -1259,6 +1286,8 @@
             document.getElementById("btn-email-search").onclick = handleEmailSearchClick;
             const rBtn = document.getElementById("copilot-refresh");
             if (devMode && rBtn) rBtn.onclick = refreshSidebar;
+            const clearSb = document.getElementById("copilot-clear");
+            if (clearSb) clearSb.onclick = clearSidebar;
             applyReviewMode();
             loadDnaSummary();
         }


### PR DESCRIPTION
## Summary
- add CLEAR button to all sidebars
- implement functions to reset sidebar data
- document new button in README
- add Clear SB button term to dictionary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864170765848326937f15b632871e66