### PR TITLE
Add Quick XRAY context menu

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The payment step logs the dropdown selector and value before clicking **Continue** so you can confirm **Client Account** is selected.
+- Added **QUICK XRAY** context menu option to run XRAY on a selected order number.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
 - Fixed the Mistral chat box disappearing after loading the order summary.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -118,6 +118,8 @@ ICONS/BUTTONS/FUNCTIONS:
    In Review Mode the sidebar stays locked to the email view across all tabs until DNA runs on a different order.
 🩻 XRAY: Runs SEARCH and DNA operations one after the other.
    Focus also returns to the original email at the end.
+QUICK XRAY: Right-click an order number and choose this option to open the order in DB,
+   search Gmail using the client and member details, and then run DNA automatically.
 🤖 FILE: Automator that opens and fills the SOS filing process.
 
 GENERAL FEATURES:

--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -21,6 +21,61 @@ function registerMistralRule() {
 
 registerMistralRule();
 
+function registerContextMenu() {
+    chrome.contextMenus.removeAll(() => {
+        chrome.contextMenus.create({
+            id: "fennec-quick-xray",
+            title: "Quick XRAY",
+            contexts: ["selection"]
+        });
+    });
+}
+
+registerContextMenu();
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+    if (info.menuItemId === "fennec-quick-xray" && info.selectionText) {
+        const digits = info.selectionText.replace(/\D/g, "");
+        if (!/^22\d{10}$/.test(digits)) return;
+        const orderId = digits;
+        const base = "https://db.incfile.com";
+        const dbUrl = `${base}/incfile/order/detail/${orderId}`;
+        chrome.tabs.create({ url: dbUrl, active: false, windowId: tab.windowId }, dbTab => {
+            if (chrome.runtime.lastError || !dbTab) return;
+            const query = { url: `${dbUrl}*` };
+            let attempts = 15;
+            const fetchInfo = () => {
+                chrome.tabs.query(query, tabs => {
+                    const t = tabs && tabs[0];
+                    if (!t || t.status !== "complete") {
+                        if (attempts-- > 0) return setTimeout(fetchInfo, 1000);
+                        return;
+                    }
+                    chrome.tabs.sendMessage(t.id, { action: "getQuickXrayData" }, resp => {
+                        if (chrome.runtime.lastError || !resp) return;
+                        const parts = [];
+                        if (resp.orderId) {
+                            parts.push(resp.orderId);
+                            parts.push(`subject:\"${resp.orderId}\"`);
+                        }
+                        if (resp.email) parts.push(`\"${resp.email}\"`);
+                        if (resp.clientName) parts.push(`\"${resp.clientName}\"`);
+                        if (resp.memberName) parts.push(`\"${resp.memberName}\"`);
+                        const queryStr = encodeURIComponent(parts.join(" OR "));
+                        const gmailUrl = `https://mail.google.com/mail/u/0/#search/${queryStr}`;
+                        chrome.tabs.create({ url: gmailUrl, active: false, windowId: tab.windowId });
+                        const adyenUrl = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
+                        chrome.storage.local.set({ fennecReturnTab: tab.id }, () => {
+                            chrome.tabs.create({ url: adyenUrl, active: true, windowId: tab.windowId });
+                        });
+                    });
+                });
+            };
+            fetchInfo();
+        });
+    }
+});
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "openTab" && message.url) {
         console.log("[Copilot] Forzando apertura de una pestaña:", message.url);

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -76,3 +76,4 @@ Retry button → Resends a prompt when the Mistral service is unavailable
 BOIR → Beneficial Ownership Information Report
 BETA → Early test version of Fennec
 Sidebar freeze → Mechanism locking sidebar data to the last processed order until XRAY runs again
+Quick XRAY → Context menu option that opens DB, Gmail search and Adyen for a selected order

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -305,6 +305,24 @@
             });
             return true;
         }
+        if (msg.action === 'getQuickXrayData') {
+            try {
+                const basic = getBasicOrderInfo();
+                const client = getClientInfo();
+                const mem = extractMembers('#vmembers .form-body', [{ name: 'name', label: 'name' }]);
+                const memberName = mem && mem.length ? mem[0].name : '';
+                sendResponse({
+                    orderId: basic.orderId,
+                    clientName: client.name || '',
+                    memberName: memberName || '',
+                    email: client.email || ''
+                });
+            } catch (err) {
+                console.warn('[FENNEC] Quick XRAY data error:', err);
+                sendResponse(null);
+            }
+            return true;
+        }
     });
     function getOrderType() {
         const el = document.getElementById("ordType");


### PR DESCRIPTION
## Summary
- add Quick XRAY context menu in background service worker
- support order info extraction for Quick XRAY in DB script
- document Quick XRAY in README and dictionary
- note new feature in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686419573ed0832695ae9cda48a5ccb7