### PR TITLE
Add quick resolve box in sidebar

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -16,6 +16,7 @@
   Mistral requests without returning **403**.
 - Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
+- Issue summary includes a QUICK RESOLVE box to add a comment and mark the issue resolved.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -127,6 +127,7 @@ GENERAL FEATURES:
 - RA and VA tags display in the COMPANY box. If the Registered Agent Service shows an expiration date in the past, the RA tag turns yellow and reads **EXPIRED**.
 - 🩺 DIAGNOSE overlay lists hold orders from the Family Tree and now displays all child orders.
 - When the sidebar is opened manually in Gmail or Adyen, it starts empty and only shows the action buttons. Order details appear after using SEARCH, DNA or XRAY.
+- A **QUICK RESOLVE** box under the Issue summary lets you add a comment and mark the issue resolved in one click.
 
 ## Known limitations
 - The scripts rely on the browser DOM provided by Chrome.

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -76,3 +76,4 @@ Retry button → Resends a prompt when the Mistral service is unavailable
 BOIR → Beneficial Ownership Information Report
 BETA → Early test version of Fennec
 Sidebar freeze → Mechanism locking sidebar data to the last processed order until XRAY runs again
+Quick Resolve box → Field under ISSUE that adds the comment and marks the issue resolved

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -433,6 +433,8 @@
                             <div class="issue-summary-box" id="issue-summary-box" style="display:none; margin-top:10px;">
                                 <strong>ISSUE <span id="issue-status-label" class="issue-status-label"></span></strong><br>
                                 <div id="issue-summary-content" style="color:#ccc; font-size:13px; white-space:pre-line;">No issue data yet.</div>
+                                <input id="issue-resolve-comment" type="text" class="issue-resolve-comment" placeholder="Comment" style="display:none; margin-top:6px; width:100%;" />
+                                <button id="issue-resolve-btn" class="copilot-button" style="display:none; margin-top:6px; width:100%;">COMMENT & RESOLVE</button>
                             </div>
                             ${devMode ? `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>` : ``}
                             <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
@@ -511,6 +513,14 @@
                             }
                         }
                         loadDnaSummary();
+                        const quickResolve = sidebar.querySelector('#issue-resolve-btn');
+                        if (quickResolve) {
+                            quickResolve.addEventListener('click', () => {
+                                const input = sidebar.querySelector('#issue-resolve-comment');
+                                const comment = input ? input.value.trim() : '';
+                                autoResolveIssue(comment);
+                            });
+                        }
                     });
                     const qsToggle = sidebar.querySelector('#qs-toggle');
                     initQuickSummary = () => {
@@ -1904,15 +1914,25 @@
         const label = document.getElementById('issue-status-label');
         if (!box || !content || !label) return;
         box.style.display = 'block';
+        const commentBox = document.getElementById('issue-resolve-comment');
+        const resolveBtn = document.getElementById('issue-resolve-btn');
         if (info && info.text) {
             content.textContent = formatIssueText(info.text);
             label.textContent = info.active ? 'ACTIVE' : 'RESOLVED';
             label.className = 'issue-status-label ' + (info.active ? 'issue-status-active' : 'issue-status-resolved');
+            if (commentBox && resolveBtn) {
+                commentBox.style.display = info.active ? 'block' : 'none';
+                resolveBtn.style.display = info.active ? 'block' : 'none';
+            }
         } else {
             const link = orderId ? `<a href="https://db.incfile.com/incfile/order/detail/${orderId}" target="_blank">${orderId}</a>` : '';
             content.innerHTML = `NO ISSUE DETECTED FROM ORDER: ${link}`;
             label.textContent = '';
             label.className = 'issue-status-label';
+            if (commentBox && resolveBtn) {
+                commentBox.style.display = 'none';
+                resolveBtn.style.display = 'none';
+            }
         }
     }
 
@@ -1948,11 +1968,18 @@
         if (dnaContainer) dnaContainer.innerHTML = '';
         const issueContent = document.getElementById('issue-summary-content');
         const issueLabel = document.getElementById('issue-status-label');
+        const issueComment = document.getElementById('issue-resolve-comment');
+        const issueBtn = document.getElementById('issue-resolve-btn');
         if (issueContent) issueContent.innerHTML = 'No issue data yet.';
         if (issueLabel) {
             issueLabel.textContent = '';
             issueLabel.className = 'issue-status-label';
         }
+        if (issueComment) {
+            issueComment.value = '';
+            issueComment.style.display = 'none';
+        }
+        if (issueBtn) issueBtn.style.display = 'none';
         updateReviewDisplay();
     }
 

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -180,6 +180,20 @@
     white-space: pre-line;
 }
 
+#issue-resolve-comment {
+    width: 100%;
+    margin-top: 6px;
+    padding: 4px;
+    border-radius: 4px;
+    border: 1px solid #888;
+    color: #000;
+}
+
+#issue-resolve-btn {
+    margin-top: 6px;
+    width: 100%;
+}
+
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
     background-color: #2e2e2e;

--- a/FENNEC/styles/sidebar_bento.css
+++ b/FENNEC/styles/sidebar_bento.css
@@ -96,3 +96,12 @@
 .fennec-bento-mode #copilot-sidebar .white-box:hover {
     transform: translateY(-2px);
 }
+
+.fennec-bento-mode #issue-resolve-comment {
+    background: #fff;
+    color: #000;
+    border-radius: 4px;
+    border: 1px solid #777;
+    padding: 4px;
+    margin-top: 6px;
+}

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -129,6 +129,12 @@
     color: #000 !important;
 }
 
+.fennec-light-mode #issue-resolve-comment {
+    background: #fff;
+    color: #000;
+    border: 1px solid #777;
+}
+
 /* Use inverted Fennec icon in light mode */
 .fennec-light-mode .copilot-icon,
 .fennec-light-mode #fennec-floating-icon,


### PR DESCRIPTION
## Summary
- add a comment field and button to quickly resolve issues in DB SB Classic
- show/hide quick resolve elements based on issue status
- reset the new field when clearing the sidebar
- document QUICK RESOLVE in README, CHANGELOG and dictionary
- style the new elements in all themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642e9ae70c832694626d8f51a57297