### PR TITLE
Fix DNA summary not showing in review mode

### DIFF
--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -294,6 +294,11 @@
                         container.innerHTML = sidebarDb.join('');
                         container.style.display = 'block';
                         attachCommonListeners(container);
+                        const qbox = container.querySelector('#quick-summary');
+                        if (qbox) {
+                            qbox.classList.remove('quick-summary-collapsed');
+                            qbox.style.maxHeight = 'none';
+                        }
                     } else {
                         container.innerHTML = '';
                         container.style.display = 'none';

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -36,14 +36,9 @@
             reviewMode = reviewMode === null ? fennecReviewMode : reviewMode === 'true';
             let currentContext = null;
             let storedOrderInfo = null;
-            if (!sessionStorage.getItem('fennecDnaCleared')) {
-                chrome.storage.local.get({ sidebarFreezeId: null }, ({ sidebarFreezeId }) => {
-                    if (!sidebarFreezeId) {
-                        chrome.storage.local.set({ adyenDnaInfo: null });
-                    }
-                });
-                sessionStorage.setItem('fennecDnaCleared', '1');
-            }
+            // Preserve the latest DNA details across Gmail pages.
+            // Older versions cleared the data on each load when no sidebar was
+            // frozen, which prevented displaying Adyen's DNA in Review Mode.
 
             // Map of US states to their SOS business search pages
             const SOS_URLS = {
@@ -807,6 +802,11 @@
                     container.innerHTML = sidebarDb.join("");
                     container.style.display = 'block';
                     attachCommonListeners(container);
+                    const qbox = container.querySelector('#quick-summary');
+                    if (qbox) {
+                        qbox.classList.remove('quick-summary-collapsed');
+                        qbox.style.maxHeight = 'none';
+                    }
                     storedOrderInfo = sidebarOrderInfo;
                     fillOrderSummaryBox(currentContext);
                 } else {


### PR DESCRIPTION
## Summary
- keep Adyen DNA data across Gmail page loads
- expand quick summary when loading DB info in Gmail/Adyen sidebars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643ca180cc8326b397a2376d2b0609