### PR TITLE
Fix DNA summary update after XRAY

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2572,7 +2572,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
             }
         });
     }
-    if (area === 'local' && changes.adyenDnaInfo && document.getElementById('dna-summary')) {
+    if (area === 'local' && changes.adyenDnaInfo) {
         loadDnaSummary();
     }
 });

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1281,6 +1281,8 @@
 
             // Start with empty layout showing only action buttons.
             showInitialStatus();
+            loadDnaSummary();
+            repositionDnaSummary();
             // Details load after the user interacts with SEARCH or when
             // opened automatically with context.
 
@@ -1365,7 +1367,7 @@
             if (area === 'local' && changes.sidebarDb && document.getElementById('db-summary-section')) {
                 loadDbSummary();
             }
-            if (area === 'local' && changes.adyenDnaInfo && document.querySelector('.copilot-dna')) {
+            if (area === 'local' && changes.adyenDnaInfo) {
                 loadDnaSummary();
             }
             if (area === 'sync' && changes.fennecReviewMode) {


### PR DESCRIPTION
## Summary
- ensure Gmail and DB sidebars refresh the DNA section whenever new data is stored
- load any stored DNA summary immediately after the Gmail sidebar is injected

## Testing
- `npm test --silent`
- `node FENNEC/manual-test.js`


------
https://chatgpt.com/codex/tasks/task_e_68643eaec3c08326a18d83e2d02689b5