### PR TITLE
Fix DNA summary refresh

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -117,3 +117,4 @@
 - Payment fields inside nested iframes are now detected so File Along selects the Client Account option reliably.
 - The payment step now verifies **Client Account** is selected before continuing.
 - Comment & Resolve in Gmail now reuses an open DB tab and only resolves when the issue is active.
+- DNA summary refreshes when returning focus to DB or Gmail so results from XRAY appear consistently.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2576,4 +2576,9 @@ chrome.storage.onChanged.addListener((changes, area) => {
         loadDnaSummary();
     }
 });
+
+// Refresh DNA summary when returning from Adyen
+window.addEventListener('focus', () => {
+    loadDnaSummary();
+});
 })();

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1380,6 +1380,11 @@
             }
         });
 
+        // Ensure DNA summary refreshes when returning from Adyen
+        window.addEventListener('focus', () => {
+            loadDnaSummary();
+        });
+
         // --- OPEN ORDER listener reutilizable ---
         function waitForElement(selector, timeout = 10000) {
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- trigger DNA summary reload when refocusing Gmail or DB tabs
- document the fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68644784a4f88326bc14ea359ad2ad35