### PR TITLE
Fix auto Family Tree on annual report

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 - Added quick resolve field below the Issue summary in Gmail.
 
+- Quick Summary no longer auto-expands on Annual Report orders and the
+  Family Tree panel loads automatically.
+
 ## v0.3 - 2025-06-24
 
 - Fixed Bento Mode positioning so the sidebar displays correctly on Gmail and DB.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -38,6 +38,13 @@
         return el ? (el.innerText || el.textContent || "").trim() : "";
     }
 
+    function autoOpenFamilyTree() {
+        const ftIcon = document.getElementById('family-tree-icon');
+        if (ftIcon && ftIcon.style.display !== 'none') {
+            ftIcon.click();
+        }
+    }
+
     function loadStoredSummary() {
         const body = document.getElementById('copilot-body-content');
         if (!body) return;
@@ -50,8 +57,7 @@
                 updateReviewDisplay();
                 checkLastIssue(currentId);
                 if (annualReportMode) {
-                    const ftIcon = document.getElementById('family-tree-icon');
-                    if (ftIcon && ftIcon.style.display !== 'none') ftIcon.click();
+                    setTimeout(autoOpenFamilyTree, 100);
                 }
             } else {
                 body.innerHTML = '<div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>';
@@ -522,13 +528,8 @@
                     initQuickSummary = () => {
                         const box = sidebar.querySelector('#quick-summary');
                         if (!box) return;
-                        if (annualReportMode) {
-                            box.classList.remove('quick-summary-collapsed');
-                            box.style.maxHeight = box.scrollHeight + 'px';
-                        } else {
-                            box.style.maxHeight = '0';
-                            box.classList.add('quick-summary-collapsed');
-                        }
+                        box.style.maxHeight = '0';
+                        box.classList.add('quick-summary-collapsed');
                     };
                     initQuickSummary();
                     if (qsToggle) {
@@ -1726,8 +1727,7 @@
             updateReviewDisplay();
             checkLastIssue(orderInfo.orderId);
             if (annualReportMode) {
-                const ftIcon = document.getElementById('family-tree-icon');
-                if (ftIcon && ftIcon.style.display !== 'none') ftIcon.click();
+                setTimeout(autoOpenFamilyTree, 100);
             }
         }
     }


### PR DESCRIPTION
## Summary
- collapse Quick Summary by default
- auto-open Family Tree after loading an Annual Report
- note the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686455132ac4832691410e8c4212d6da