### PR TITLE
Fix company summary highlight text color

### DIFF
--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -352,6 +352,10 @@
     padding: 4px;
     margin-bottom: 6px;
 }
+#copilot-sidebar .white-box .company-summary-highlight,
+#copilot-sidebar .white-box .company-summary-highlight * {
+    color: #000 !important;
+}
 .copilot-tag.tx-label {
     color: #000 !important;
 }

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -99,6 +99,10 @@
     padding: 4px;
     margin-bottom: 6px;
 }
+.fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight,
+.fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight * {
+    color: #000 !important;
+}
 .fennec-light-mode #copilot-sidebar .copilot-tag-yellow {
     background-color: #f7bc00;
     color: #000 !important;


### PR DESCRIPTION
## Summary
- ensure the light grey box inside the company summary uses black text
- apply same rule in light mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68646424fe988326a6305e7499205512