### PR TITLE
Improve Gmail quick resolve flow

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 - Added quick resolve field below the Issue summary in Gmail.
+- Quick resolve button now shows **COMMENT** when the issue is already resolved
+  and automatically returns focus to Gmail with a success message.
 
 - Quick Summary no longer auto-expands on Annual Report orders and the
   Family Tree panel loads automatically.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2074,6 +2074,8 @@
                 save.click();
                 sessionStorage.removeItem('fennecAutoComment');
                 sessionStorage.setItem('fennecAddComment', comment);
+                chrome.storage.local.set({ fennecQuickResolveDone: Date.now() });
+                chrome.runtime.sendMessage({ action: 'refocusTab' });
             } else {
                 setTimeout(fillComment, 500);
             }
@@ -2099,6 +2101,8 @@
             if (ta && add) {
                 ta.value = comment;
                 add.click();
+                chrome.storage.local.set({ fennecQuickResolveDone: Date.now() });
+                chrome.runtime.sendMessage({ action: 'refocusTab' });
             } else {
                 setTimeout(fill, 500);
             }

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1048,17 +1048,20 @@
             const box = document.getElementById('issue-summary-box');
             const content = document.getElementById('issue-summary-content');
             const label = document.getElementById('issue-status-label');
+            const btn = document.getElementById('issue-resolve-btn');
             if (!box || !content || !label) return;
             box.style.display = 'block';
             if (info && info.text) {
                 content.textContent = formatIssueText(info.text);
                 label.textContent = info.active ? 'ACTIVE' : 'RESOLVED';
                 label.className = 'issue-status-label ' + (info.active ? 'issue-status-active' : 'issue-status-resolved');
+                if (btn) btn.textContent = info.active ? 'RESOLVE & COMMENT' : 'COMMENT';
             } else {
                 const link = orderId ? `<a href="https://db.incfile.com/incfile/order/detail/${orderId}" target="_blank">${orderId}</a>` : '';
                 content.innerHTML = `NO ISSUE DETECTED FROM ORDER: ${link}`;
                 label.textContent = '';
                 label.className = 'issue-status-label';
+                if (btn) btn.textContent = 'COMMENT';
             }
         }
 
@@ -1327,15 +1330,7 @@
                     }
                     chrome.storage.local.set({ fennecPendingComment: { orderId, comment } }, () => {
                         const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
-                        chrome.windows.getCurrent(win => {
-                            chrome.tabs.query({ url: `${url}*`, windowId: win.id }, tabs => {
-                                if (tabs && tabs.length) {
-                                    chrome.tabs.update(tabs[0].id, { active: true });
-                                } else {
-                                    chrome.runtime.sendMessage({ action: "openActiveTab", url });
-                                }
-                            });
-                        });
+                        chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
                     });
                 };
             }
@@ -1377,6 +1372,10 @@
             }
             if ((area === 'sync' && changes.fennecDevMode) || (area === 'local' && changes.fennecDevMode)) {
                 window.location.reload();
+            }
+            if (area === 'local' && changes.fennecQuickResolveDone) {
+                alert('Issue updated successfully.');
+                chrome.storage.local.remove('fennecQuickResolveDone');
             }
         });
 

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -181,12 +181,13 @@
 }
 
 .quick-resolve-comment {
-    width: 100%;
-    margin-top: 6px;
+    width: calc(100% - 8px);
+    margin: 6px 4px 0;
     padding: 4px;
     border-radius: 4px;
     border: 1px solid #888;
     color: #000;
+    box-sizing: border-box;
 }
 
 /* Ensure DB sidebar sections remain readable */


### PR DESCRIPTION
## Summary
- tweak quick resolve comment field width
- change button label depending on issue status
- open DB tab with refocus when resolving from Gmail
- send success event from DB and show alert in Gmail
- document quick resolve improvements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68646362172483269db7ea5b616c93d6