### PR TITLE
Fix company summary box styling and copy icon

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1546,7 +1546,9 @@
                 nameText = `<a href="#" class="copilot-sos" data-url="${nameBase}" data-query="${escapeHtml(company.name)}" data-type="name">${nameText}</a>`;
             }
             highlight.push(`<div><b>${nameText} ${renderCopyIcon(company.name)}</b></div>`);
-            if (orderIdHighlight) highlight.push(`<div><b>${renderCopy(orderIdHighlight)}</b></div>`);
+            if (orderIdHighlight) {
+                highlight.push(`<div><b>${renderCopy(orderIdHighlight)} ${renderCopyIcon(orderIdHighlight)}</b></div>`);
+            }
             if (company.stateId && company.stateId.toLowerCase() !== 'n/a') {
                 let idHtml = escapeHtml(company.stateId);
                 const idBase = buildSosUrl(company.state, null, 'id');
@@ -1558,7 +1560,9 @@
                 }
                 highlight.push(`<div><b>${idHtml}</b></div>`);
             }
-            if (company.formationDate) highlight.push(`<div><b>${escapeHtml(company.formationDate)}</b></div>`);
+            if (company.formationDate && company.formationDate.toLowerCase() !== 'n/a') {
+                highlight.push(`<div><b>${escapeHtml(company.formationDate)}</b></div>`);
+            }
             companyLines.push(`<div class="company-summary-highlight">${highlight.join('')}</div>`);
             companyLines.push(`<div>${renderKb(company.state)}</div>`);
             companyLines.push(addrHtml);

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -349,6 +349,7 @@
 .company-summary-highlight {
     background-color: #ddd;
     color: #000 !important;
+    font-weight: bold;
     border-radius: 4px;
     padding: 4px;
     margin-bottom: 6px;
@@ -356,6 +357,7 @@
 #copilot-sidebar .white-box .company-summary-highlight,
 #copilot-sidebar .white-box .company-summary-highlight * {
     color: #000 !important;
+    font-weight: bold;
 }
 .copilot-tag.tx-label {
     color: #000 !important;

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -94,6 +94,7 @@
 .fennec-light-mode #copilot-sidebar .company-summary-highlight {
     background-color: #ddd;
     color: #000 !important;
+    font-weight: bold;
     border: 1px solid #777;
     border-radius: 4px;
     padding: 4px;
@@ -102,6 +103,7 @@
 .fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight,
 .fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight * {
     color: #000 !important;
+    font-weight: bold;
 }
 .fennec-light-mode #copilot-sidebar .copilot-tag-yellow {
     background-color: #f7bc00;


### PR DESCRIPTION
## Summary
- make company summary highlight text black and bold
- show a copy icon next to the order number
- hide formation date when value is `N/A`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686466faacf48326800530ef185acf1f