### PR TITLE
Improve SOS search actions

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -360,7 +360,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     if (message.action === "sosSearch" && message.url && message.query) {
-        const origin = new URL(message.url).origin + "/*";
         const openSearchTab = () => {
             chrome.tabs.create({ url: message.url, active: true }, (tab) => {
                 if (chrome.runtime.lastError) {
@@ -372,8 +371,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                         target: { tabId },
                         func: (q, type) => {
                             const patterns = type === "id"
-                                ? ["id", "number", "document", "control"]
-                                : ["name", "business", "entity"];
+                                ? ["id", "number", "document", "control", "filing", "account"]
+                                : ["name", "business", "entity", "organization", "company", "keyword", "search"];
                             let attempts = 10;
                             const run = () => {
                                 const inputs = Array.from(document.querySelectorAll("input,textarea"));
@@ -415,22 +414,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             });
         };
 
-        chrome.permissions.contains({ origins: [origin] }, (has) => {
-            const requestAndOpen = () => {
-                chrome.permissions.request({ origins: [origin] }, (granted) => {
-                    if (granted) {
-                        openSearchTab();
-                    } else if (sender.tab && sender.tab.id) {
-                        chrome.tabs.sendMessage(sender.tab.id, { action: "sosPermissionError" });
-                    }
-                });
-            };
-            if (has) {
-                openSearchTab();
-            } else {
-                requestAndOpen();
-            }
-        });
+        openSearchTab();
         return;
     }
 

--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -44,6 +44,7 @@ function attachCommonListeners(rootEl) {
             const query = el.dataset.query;
             const type = el.dataset.type || 'name';
             if (!url || !query) return;
+            navigator.clipboard.writeText(query).catch(err => console.warn('[Copilot] Clipboard', err));
             chrome.runtime.sendMessage({ action: 'sosSearch', url, query, searchType: type });
         });
     });

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -18,7 +18,8 @@
         "https://coda.io/*",
         "https://ca-live.adyen.com/*",
         "https://direct.sos.state.tx.us/*",
-        "http://127.0.0.1:11434/*"
+        "http://127.0.0.1:11434/*",
+        "https://*/*"
     ],
   "optional_host_permissions": [
     "https://*/*"


### PR DESCRIPTION
## Summary
- grant blanket host permissions so SOS lookups don't require user approval
- stop requesting permissions when opening SOS search tabs
- broaden patterns for detecting name and ID search fields
- copy query to clipboard when clicking name or State ID links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686468356ef8832692fe7074fe0cc393