### PR TITLE
Implement Quick Resolve improvements

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Quick resolve button now shows **COMMENT** when the issue is already resolved
   and automatically returns focus to Gmail with a success message.
 
+- Quick resolve now reuses an existing DB tab when available and displays the
+  completion message inside the Gmail sidebar instead of using a popup.
+
 - Quick Summary no longer auto-expands on Annual Report orders and the
   Family Tree panel loads automatically.
 

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1330,7 +1330,7 @@
                     }
                     chrome.storage.local.set({ fennecPendingComment: { orderId, comment } }, () => {
                         const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
-                        chrome.runtime.sendMessage({ action: "openTab", url, refocus: true, active: true });
+                        chrome.runtime.sendMessage({ action: "openOrReuseTab", url, refocus: true, active: true });
                     });
                 };
             }
@@ -1374,8 +1374,21 @@
                 window.location.reload();
             }
             if (area === 'local' && changes.fennecQuickResolveDone) {
-                alert('Issue updated successfully.');
                 chrome.storage.local.remove('fennecQuickResolveDone');
+                const box = document.getElementById('issue-summary-box');
+                if (box) {
+                    let msg = document.getElementById('quick-resolve-confirm');
+                    if (!msg) {
+                        msg = document.createElement('div');
+                        msg.id = 'quick-resolve-confirm';
+                        msg.style.marginTop = '4px';
+                        msg.style.color = '#0a0';
+                        box.appendChild(msg);
+                    }
+                    msg.textContent = 'Issue updated successfully.';
+                    msg.style.display = 'block';
+                    setTimeout(() => { if (msg) msg.style.display = 'none'; }, 3000);
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- add `openOrReuseTab` message handler to reuse open DB tabs
- use the new handler from Gmail Quick Resolve
- show completion notice inside the Gmail sidebar
- document the changes in `CHANGELOG`

## Testing
- `npm test --prefix FENNEC`

------
https://chatgpt.com/codex/tasks/task_e_68654757aac08326bfef4d530cf76026