### PR TITLE
Add sidebar design customization

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 - Added quick resolve field below the Issue summary in Gmail.
+- Sidebar design can now be customized from the Options page, including font size,
+  font family and colors.
 - Quick resolve button now shows **COMMENT** when the issue is already resolved
   and automatically returns focus to Gmail with a success message.
 

--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -10,6 +10,24 @@ function escapeHtml(text) {
         .replace(/'/g, "&#039;");
 }
 
+function applySidebarDesign(sidebar, opts) {
+    if (!sidebar || !opts) return;
+    if (opts.sidebarBgColor) {
+        sidebar.style.setProperty('--sb-bg', opts.sidebarBgColor);
+    }
+    if (opts.sidebarBoxColor) {
+        sidebar.style.setProperty('--sb-box-bg', opts.sidebarBoxColor);
+    }
+    const fs = parseInt(opts.sidebarFontSize, 10);
+    if (fs) {
+        sidebar.style.setProperty('--sb-font-size', fs + 'px');
+    }
+    if (opts.sidebarFont) {
+        sidebar.style.setProperty('--sb-font-family', opts.sidebarFont);
+    }
+}
+window.applySidebarDesign = applySidebarDesign;
+
 function attachCommonListeners(rootEl) {
     if (!rootEl) return;
     rootEl.querySelectorAll('.copilot-address').forEach(el => {

--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -399,6 +399,12 @@
                         <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                     </div>`;
                 document.body.appendChild(sidebar);
+                chrome.storage.sync.get({
+                    sidebarFontSize: 13,
+                    sidebarFont: "'Inter', sans-serif",
+                    sidebarBgColor: '#212121',
+                    sidebarBoxColor: '#2e2e2e'
+                }, opts => applySidebarDesign(sidebar, opts));
                 document.body.style.marginRight = '340px';
                 const closeBtn = sidebar.querySelector('#copilot-close');
                 if (closeBtn) {

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -460,6 +460,12 @@
                         </div>
                     `;
                     document.body.appendChild(sidebar);
+                    chrome.storage.sync.get({
+                        sidebarFontSize: 13,
+                        sidebarFont: "'Inter', sans-serif",
+                        sidebarBgColor: '#212121',
+                        sidebarBoxColor: '#2e2e2e'
+                    }, opts => applySidebarDesign(sidebar, opts));
                     if (document.body.classList.contains('fennec-bento-mode')) {
                         const vid = document.createElement('video');
                         vid.id = 'bento-video';

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1262,6 +1262,12 @@
                 </div>
             `;
             document.body.appendChild(sidebar);
+            chrome.storage.sync.get({
+                sidebarFontSize: 13,
+                sidebarFont: "'Inter', sans-serif",
+                sidebarBgColor: '#212121',
+                sidebarBoxColor: '#2e2e2e'
+            }, opts => applySidebarDesign(sidebar, opts));
             if (document.body.classList.contains('fennec-bento-mode')) {
                 const vid = document.createElement('video');
                 vid.id = 'bento-video';

--- a/FENNEC/options.html
+++ b/FENNEC/options.html
@@ -20,6 +20,30 @@
         <input type="number" id="sidebar-width" min="200" max="500" step="10">
     </label>
     <label>
+        Font size
+        <select id="sidebar-font-size">
+            <option value="13">Small</option>
+            <option value="15">Mid</option>
+            <option value="17">Big</option>
+        </select>
+    </label>
+    <label>
+        Font family
+        <select id="sidebar-font">
+            <option value="'Inter', sans-serif">Inter</option>
+            <option value="Arial, sans-serif">Arial</option>
+            <option value="'Times New Roman', serif">Times New Roman</option>
+        </select>
+    </label>
+    <label>
+        Sidebar background
+        <input type="color" id="sidebar-bg-color">
+    </label>
+    <label>
+        Box background
+        <input type="color" id="sidebar-box-color">
+    </label>
+    <label>
         TX SOS User ID
         <input type="text" id="txsos-user">
     </label>

--- a/FENNEC/options.js
+++ b/FENNEC/options.js
@@ -4,24 +4,47 @@ document.addEventListener("DOMContentLoaded", () => {
     const reviewBox = document.getElementById("default-review");
     const devBox = document.getElementById("default-dev");
     const widthInput = document.getElementById("sidebar-width");
+    const fontSizeSelect = document.getElementById("sidebar-font-size");
+    const fontSelect = document.getElementById("sidebar-font");
+    const bgColorInput = document.getElementById("sidebar-bg-color");
+    const boxColorInput = document.getElementById("sidebar-box-color");
     const userInput = document.getElementById("txsos-user");
     const passInput = document.getElementById("txsos-pass");
     const saveBtn = document.getElementById("save-btn");
 
-    chrome.storage.sync.get({ defaultReviewMode: false, defaultDevMode: false, sidebarWidth: 340, txsosUser: "", txsosPass: "" }, (opts) => {
+    chrome.storage.sync.get({
+        defaultReviewMode: false,
+        defaultDevMode: false,
+        sidebarWidth: 340,
+        sidebarFontSize: 13,
+        sidebarFont: "'Inter', sans-serif",
+        sidebarBgColor: "#212121",
+        sidebarBoxColor: "#2e2e2e",
+        txsosUser: "",
+        txsosPass: ""
+    }, (opts) => {
         reviewBox.checked = Boolean(opts.defaultReviewMode);
         devBox.checked = Boolean(opts.defaultDevMode);
         widthInput.value = parseInt(opts.sidebarWidth, 10) || 340;
+        fontSizeSelect.value = String(opts.sidebarFontSize || 13);
+        fontSelect.value = opts.sidebarFont || "'Inter', sans-serif";
+        bgColorInput.value = opts.sidebarBgColor || "#212121";
+        boxColorInput.value = opts.sidebarBoxColor || "#2e2e2e";
         userInput.value = opts.txsosUser || "";
         passInput.value = opts.txsosPass || "";
     });
 
     function save() {
         const width = parseInt(widthInput.value, 10) || 340;
+        const fontSize = parseInt(fontSizeSelect.value, 10) || 13;
         chrome.storage.sync.set({
             defaultReviewMode: reviewBox.checked,
             defaultDevMode: devBox.checked,
             sidebarWidth: width,
+            sidebarFontSize: fontSize,
+            sidebarFont: fontSelect.value,
+            sidebarBgColor: bgColorInput.value,
+            sidebarBoxColor: boxColorInput.value,
             txsosUser: userInput.value,
             txsosPass: passInput.value,
             fennecReviewMode: reviewBox.checked,

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -1,15 +1,21 @@
 #copilot-sidebar {
+    --sb-bg: #212121;
+    --sb-text: #fff;
+    --sb-box-bg: #2e2e2e;
+    --sb-font-size: 13px;
+    --sb-font-family: 'Inter', sans-serif;
     position: fixed;
     top: 0; right: 0;
     width: 340px;
     height: 100vh;
-    background: #212121;
-    color: #fff;
+    background: var(--sb-bg);
+    color: var(--sb-text);
     z-index: 1060;
     box-shadow: -2px 0 16px rgba(0,0,0,0.22);
     display: flex;
     flex-direction: column;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--sb-font-family);
+    font-size: var(--sb-font-size);
     transition: transform 0.2s;
 }
 .copilot-header {
@@ -145,7 +151,7 @@
 }
 
 .order-summary-box {
-    background-color: #2e2e2e;
+    background-color: var(--sb-box-bg);
     color: #f1f1f1;
     padding: 8px;
     margin-top: 12px;
@@ -156,7 +162,7 @@
 }
 
 .intel-summary-box {
-    background-color: #2e2e2e;
+    background-color: var(--sb-box-bg);
     color: #f1f1f1;
     padding: 8px;
     margin-top: 12px;
@@ -167,7 +173,7 @@
 }
 
 .issue-summary-box {
-    background-color: #3a3a3a;
+    background-color: var(--sb-box-bg);
     color: #f1f1f1;
     padding: 8px;
     margin-top: 12px;
@@ -192,7 +198,7 @@
 
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
-    background-color: #2e2e2e;
+    background-color: var(--sb-box-bg);
     color: #f1f1f1 !important;
     border-radius: 8px;
     font-size: 13px;
@@ -555,7 +561,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: #2e2e2e;
+    background: var(--sb-box-bg);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -587,7 +593,7 @@
     margin: 8px;
     padding: 8px;
     border-radius: 8px;
-    background: #3a3a3a;
+    background: var(--sb-box-bg);
     color: #f1f1f1;
     text-align: center;
 }
@@ -619,7 +625,7 @@
 }
 
 #fennec-diagnose-overlay .diag-issue {
-    background: #2e2e2e;
+    background: var(--sb-box-bg);
     border-radius: 6px;
     padding: 6px;
     margin-top: 6px;
@@ -632,7 +638,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: #2e2e2e;
+    background: var(--sb-box-bg);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -688,7 +694,7 @@
     width: 70%;
     height: 70%;
     max-height: 90%;
-    background: #2e2e2e;
+    background: var(--sb-box-bg);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -715,7 +721,7 @@
 
 /* Mistral chat box */
 .mistral-box {
-    background-color: #2e2e2e;
+    background-color: var(--sb-box-bg);
     color: #f1f1f1;
     padding: 8px;
     margin-top: 12px;


### PR DESCRIPTION
## Summary
- allow picking font size, font family, sidebar/box colors from Options page
- save new design options in `chrome.storage`
- apply custom design when injecting sidebars
- expose helper `applySidebarDesign()`
- use CSS variables for sidebar styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68654a096a6483268c724d6ff858aac4