### PR TITLE
Add customizable themes to options UI

### DIFF
--- a/FENNEC/options.html
+++ b/FENNEC/options.html
@@ -2,60 +2,99 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <style>
-        body { font-family: Arial, sans-serif; width: 250px; padding: 10px; }
-        label { display: block; margin-top: 8px; }
-    </style>
+    <link rel="stylesheet" href="styles/options.css">
 </head>
 <body>
-    <h2>FENNEC Options</h2>
-    <div id="sidebar-preview" style="--preview-width:340px; --preview-bg:#212121; --preview-box-bg:#2e2e2e; --preview-font:'Inter', sans-serif; --preview-font-size:13px; width:var(--preview-width); background:var(--preview-bg); color:#fff; font-family:var(--preview-font); font-size:var(--preview-font-size); border:1px solid #888; border-radius:4px; margin-bottom:10px;">
-        <div class="header" style="background:#c6c6c6; color:#000; padding:6px; font-weight:bold;">Sidebar Preview</div>
-        <div class="white-box" style="background:var(--preview-box-bg); margin:8px; padding:8px; border-radius:4px; text-align:center;">Example Box</div>
+    <h2 class="page-title">FENNEC Options</h2>
+    <div class="options-grid">
+        <div class="controls">
+            <div class="bento">
+                <label for="sidebar-theme">Theme</label>
+                <select id="sidebar-theme">
+                    <option value="classic">Classic</option>
+                    <option value="light">Light</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div class="bento">
+                <label><input type="checkbox" id="default-review"> Default Review Mode</label>
+                <label><input type="checkbox" id="default-dev"> Default Dev Mode</label>
+            </div>
+            <div class="bento custom-only">
+                <label>Sidebar width (px)
+                    <input type="number" id="sidebar-width" min="200" max="500" step="10">
+                </label>
+                <label>Font family
+                    <select id="sidebar-font">
+                        <option value="'Inter', sans-serif">Inter</option>
+                        <option value="Arial, sans-serif">Arial</option>
+                        <option value="'Times New Roman', serif">Times New Roman</option>
+                    </select>
+                </label>
+                <label>Font size
+                    <select id="sidebar-font-size">
+                        <option value="13">Small</option>
+                        <option value="15">Mid</option>
+                        <option value="17">Big</option>
+                    </select>
+                </label>
+                <label>Header font size
+                    <input type="number" id="header-font-size" min="12" max="20" step="1">
+                </label>
+                <label><input type="checkbox" id="header-bold"> Bold header</label>
+                <label>Line 1 size
+                    <input type="number" id="line1-size" min="11" max="18" step="1">
+                </label>
+                <label><input type="checkbox" id="line1-bold"> Bold line 1</label>
+                <label>Line 2 size
+                    <input type="number" id="line2-size" min="11" max="18" step="1">
+                </label>
+                <label><input type="checkbox" id="line2-bold"> Bold line 2</label>
+                <label>Line 3 size
+                    <input type="number" id="line3-size" min="11" max="18" step="1">
+                </label>
+                <label><input type="checkbox" id="line3-bold"> Bold line 3</label>
+                <label>Sidebar background
+                    <input type="color" id="sidebar-bg-color">
+                </label>
+                <label>Box background
+                    <input type="color" id="sidebar-box-color">
+                </label>
+                <label>Button color
+                    <input type="color" id="button-color">
+                </label>
+                <label>Button radius
+                    <input type="number" id="button-radius" min="0" max="20" step="1">
+                </label>
+                <label>Icon style
+                    <select id="icon-set">
+                        <option value="default">Default</option>
+                        <option value="minimal">Minimal</option>
+                    </select>
+                </label>
+            </div>
+            <div class="bento">
+                <label>TX SOS User ID
+                    <input type="text" id="txsos-user">
+                </label>
+                <label>TX SOS Password
+                    <input type="password" id="txsos-pass">
+                </label>
+            </div>
+            <button id="save-btn" class="save-button">Save</button>
+        </div>
+        <div class="preview">
+            <div id="sidebar-preview" class="sidebar-preview">
+                <div class="header">Sidebar Preview</div>
+                <div class="white-box">
+                    <div class="line1">Line 1</div>
+                    <div class="line2">Line 2</div>
+                    <div class="line3">Line 3</div>
+                </div>
+                <button class="example-button">Button</button>
+            </div>
+        </div>
     </div>
-    <label>
-        <input type="checkbox" id="default-review"> Default Review Mode
-    </label>
-    <label>
-        <input type="checkbox" id="default-dev"> Default Dev Mode
-    </label>
-    <label>
-        Sidebar width (px)
-        <input type="number" id="sidebar-width" min="200" max="500" step="10">
-    </label>
-    <label>
-        Font size
-        <select id="sidebar-font-size">
-            <option value="13">Small</option>
-            <option value="15">Mid</option>
-            <option value="17">Big</option>
-        </select>
-    </label>
-    <label>
-        Font family
-        <select id="sidebar-font">
-            <option value="'Inter', sans-serif">Inter</option>
-            <option value="Arial, sans-serif">Arial</option>
-            <option value="'Times New Roman', serif">Times New Roman</option>
-        </select>
-    </label>
-    <label>
-        Sidebar background
-        <input type="color" id="sidebar-bg-color">
-    </label>
-    <label>
-        Box background
-        <input type="color" id="sidebar-box-color">
-    </label>
-    <label>
-        TX SOS User ID
-        <input type="text" id="txsos-user">
-    </label>
-    <label>
-        TX SOS Password
-        <input type="password" id="txsos-pass">
-    </label>
-    <button id="save-btn" style="margin-top:10px;">Save</button>
     <script src="options.js"></script>
 </body>
 </html>

--- a/FENNEC/options.js
+++ b/FENNEC/options.js
@@ -3,15 +3,34 @@
 document.addEventListener("DOMContentLoaded", () => {
     const reviewBox = document.getElementById("default-review");
     const devBox = document.getElementById("default-dev");
+    const themeSelect = document.getElementById("sidebar-theme");
     const widthInput = document.getElementById("sidebar-width");
     const fontSizeSelect = document.getElementById("sidebar-font-size");
     const fontSelect = document.getElementById("sidebar-font");
     const bgColorInput = document.getElementById("sidebar-bg-color");
     const boxColorInput = document.getElementById("sidebar-box-color");
+    const headerFontSizeInput = document.getElementById("header-font-size");
+    const headerBold = document.getElementById("header-bold");
+    const line1SizeInput = document.getElementById("line1-size");
+    const line1Bold = document.getElementById("line1-bold");
+    const line2SizeInput = document.getElementById("line2-size");
+    const line2Bold = document.getElementById("line2-bold");
+    const line3SizeInput = document.getElementById("line3-size");
+    const line3Bold = document.getElementById("line3-bold");
+    const buttonColorInput = document.getElementById("button-color");
+    const buttonRadiusInput = document.getElementById("button-radius");
+    const iconSetSelect = document.getElementById("icon-set");
     const userInput = document.getElementById("txsos-user");
     const passInput = document.getElementById("txsos-pass");
     const saveBtn = document.getElementById("save-btn");
     const preview = document.getElementById("sidebar-preview");
+
+    const customSections = Array.from(document.querySelectorAll('.custom-only'));
+
+    function toggleCustom() {
+        const show = themeSelect.value === 'custom';
+        customSections.forEach(div => div.style.display = show ? 'flex' : 'none');
+    }
 
     function updatePreview() {
         preview.style.setProperty("--preview-width", `${widthInput.value}px`);
@@ -19,9 +38,20 @@ document.addEventListener("DOMContentLoaded", () => {
         preview.style.setProperty("--preview-font", fontSelect.value);
         preview.style.setProperty("--preview-bg", bgColorInput.value);
         preview.style.setProperty("--preview-box-bg", boxColorInput.value);
+        preview.style.setProperty("--header-font-size", `${headerFontSizeInput.value}px`);
+        preview.style.setProperty("--header-bold", headerBold.checked ? '700' : '400');
+        preview.style.setProperty("--line1-size", `${line1SizeInput.value}px`);
+        preview.style.setProperty("--line1-bold", line1Bold.checked ? '700' : '400');
+        preview.style.setProperty("--line2-size", `${line2SizeInput.value}px`);
+        preview.style.setProperty("--line2-bold", line2Bold.checked ? '700' : '400');
+        preview.style.setProperty("--line3-size", `${line3SizeInput.value}px`);
+        preview.style.setProperty("--line3-bold", line3Bold.checked ? '700' : '400');
+        preview.style.setProperty("--button-color", buttonColorInput.value);
+        preview.style.setProperty("--button-radius", `${buttonRadiusInput.value}px`);
     }
 
     chrome.storage.sync.get({
+        theme: 'classic',
         defaultReviewMode: false,
         defaultDevMode: false,
         sidebarWidth: 340,
@@ -29,9 +59,21 @@ document.addEventListener("DOMContentLoaded", () => {
         sidebarFont: "'Inter', sans-serif",
         sidebarBgColor: "#212121",
         sidebarBoxColor: "#2e2e2e",
+        headerFontSize: 14,
+        headerBold: true,
+        line1Size: 13,
+        line1Bold: false,
+        line2Size: 13,
+        line2Bold: false,
+        line3Size: 13,
+        line3Bold: false,
+        buttonColor: "#333333",
+        buttonRadius: 6,
+        iconSet: 'default',
         txsosUser: "",
         txsosPass: ""
     }, (opts) => {
+        themeSelect.value = opts.theme || 'classic';
         reviewBox.checked = Boolean(opts.defaultReviewMode);
         devBox.checked = Boolean(opts.defaultDevMode);
         widthInput.value = parseInt(opts.sidebarWidth, 10) || 340;
@@ -39,15 +81,68 @@ document.addEventListener("DOMContentLoaded", () => {
         fontSelect.value = opts.sidebarFont || "'Inter', sans-serif";
         bgColorInput.value = opts.sidebarBgColor || "#212121";
         boxColorInput.value = opts.sidebarBoxColor || "#2e2e2e";
+        headerFontSizeInput.value = parseInt(opts.headerFontSize,10) || 14;
+        headerBold.checked = Boolean(opts.headerBold);
+        line1SizeInput.value = parseInt(opts.line1Size,10) || 13;
+        line1Bold.checked = Boolean(opts.line1Bold);
+        line2SizeInput.value = parseInt(opts.line2Size,10) || 13;
+        line2Bold.checked = Boolean(opts.line2Bold);
+        line3SizeInput.value = parseInt(opts.line3Size,10) || 13;
+        line3Bold.checked = Boolean(opts.line3Bold);
+        buttonColorInput.value = opts.buttonColor || '#333333';
+        buttonRadiusInput.value = parseInt(opts.buttonRadius,10) || 6;
+        iconSetSelect.value = opts.iconSet || 'default';
         userInput.value = opts.txsosUser || "";
         passInput.value = opts.txsosPass || "";
+        toggleCustom();
         updatePreview();
     });
+
+    function applyTheme(theme) {
+        if (theme === 'classic') {
+            widthInput.value = 340;
+            fontSizeSelect.value = '13';
+            fontSelect.value = "'Inter', sans-serif";
+            bgColorInput.value = '#212121';
+            boxColorInput.value = '#2e2e2e';
+            headerFontSizeInput.value = 14;
+            headerBold.checked = true;
+            line1SizeInput.value = 13;
+            line1Bold.checked = false;
+            line2SizeInput.value = 13;
+            line2Bold.checked = false;
+            line3SizeInput.value = 13;
+            line3Bold.checked = false;
+            buttonColorInput.value = '#333333';
+            buttonRadiusInput.value = 6;
+            iconSetSelect.value = 'default';
+        } else if (theme === 'light') {
+            widthInput.value = 340;
+            fontSizeSelect.value = '13';
+            fontSelect.value = "'Inter', sans-serif";
+            bgColorInput.value = '#ffffff';
+            boxColorInput.value = '#f4f4f4';
+            headerFontSizeInput.value = 14;
+            headerBold.checked = true;
+            line1SizeInput.value = 13;
+            line1Bold.checked = false;
+            line2SizeInput.value = 13;
+            line2Bold.checked = false;
+            line3SizeInput.value = 13;
+            line3Bold.checked = false;
+            buttonColorInput.value = '#005a9c';
+            buttonRadiusInput.value = 6;
+            iconSetSelect.value = 'default';
+        }
+        toggleCustom();
+        updatePreview();
+    }
 
     function save() {
         const width = parseInt(widthInput.value, 10) || 340;
         const fontSize = parseInt(fontSizeSelect.value, 10) || 13;
         chrome.storage.sync.set({
+            theme: themeSelect.value,
             defaultReviewMode: reviewBox.checked,
             defaultDevMode: devBox.checked,
             sidebarWidth: width,
@@ -55,6 +150,17 @@ document.addEventListener("DOMContentLoaded", () => {
             sidebarFont: fontSelect.value,
             sidebarBgColor: bgColorInput.value,
             sidebarBoxColor: boxColorInput.value,
+            headerFontSize: parseInt(headerFontSizeInput.value,10) || 14,
+            headerBold: headerBold.checked,
+            line1Size: parseInt(line1SizeInput.value,10) || 13,
+            line1Bold: line1Bold.checked,
+            line2Size: parseInt(line2SizeInput.value,10) || 13,
+            line2Bold: line2Bold.checked,
+            line3Size: parseInt(line3SizeInput.value,10) || 13,
+            line3Bold: line3Bold.checked,
+            buttonColor: buttonColorInput.value,
+            buttonRadius: parseInt(buttonRadiusInput.value,10) || 6,
+            iconSet: iconSetSelect.value,
             txsosUser: userInput.value,
             txsosPass: passInput.value,
             fennecReviewMode: reviewBox.checked,
@@ -63,6 +169,11 @@ document.addEventListener("DOMContentLoaded", () => {
         chrome.storage.local.set({ fennecReviewMode: reviewBox.checked, fennecDevMode: devBox.checked });
     }
 
-    [widthInput, fontSizeSelect, fontSelect, bgColorInput, boxColorInput].forEach(el => el.addEventListener("input", updatePreview));
+    [widthInput, fontSizeSelect, fontSelect, bgColorInput, boxColorInput,
+     headerFontSizeInput, line1SizeInput, line2SizeInput, line3SizeInput,
+     buttonColorInput, buttonRadiusInput].forEach(el => el.addEventListener("input", updatePreview));
+    [headerBold, line1Bold, line2Bold, line3Bold].forEach(el => el.addEventListener('change', updatePreview));
+    themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
+    iconSetSelect.addEventListener('change', updatePreview);
     saveBtn.addEventListener("click", () => { save(); updatePreview(); });
 });

--- a/FENNEC/styles/options.css
+++ b/FENNEC/styles/options.css
@@ -1,0 +1,111 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 10px;
+    color: #222;
+}
+
+.page-title {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.options-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.bento {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 10px;
+    background: #f9f9f9;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+label {
+    font-size: 12px;
+}
+
+.sidebar-preview {
+    --preview-width:340px;
+    --preview-bg:#212121;
+    --preview-box-bg:#2e2e2e;
+    --preview-font:'Inter', sans-serif;
+    --preview-font-size:13px;
+    --header-font-size:14px;
+    --header-bold:700;
+    --line1-size:13px;
+    --line1-bold:400;
+    --line2-size:13px;
+    --line2-bold:400;
+    --line3-size:13px;
+    --line3-bold:400;
+    --button-color:#333333;
+    --button-radius:6px;
+
+    width:var(--preview-width);
+    background:var(--preview-bg);
+    color:#fff;
+    font-family:var(--preview-font);
+    font-size:var(--preview-font-size);
+    border:1px solid #888;
+    border-radius:4px;
+    padding:6px;
+}
+
+.sidebar-preview .header {
+    background:#c6c6c6;
+    color:#000;
+    padding:4px 6px;
+    font-size:var(--header-font-size);
+    font-weight:var(--header-bold);
+    border-radius:4px;
+}
+
+.sidebar-preview .white-box {
+    background:var(--preview-box-bg);
+    margin:8px 0;
+    padding:8px;
+    border-radius:4px;
+    text-align:left;
+    font-size:13px;
+}
+
+.sidebar-preview .line1 { font-size:var(--line1-size); font-weight:var(--line1-bold); }
+.sidebar-preview .line2 { font-size:var(--line2-size); font-weight:var(--line2-bold); }
+.sidebar-preview .line3 { font-size:var(--line3-size); font-weight:var(--line3-bold); }
+
+.example-button {
+    background:var(--button-color);
+    color:#fff;
+    border:none;
+    border-radius:var(--button-radius);
+    padding:6px 12px;
+    font-weight:bold;
+    cursor:pointer;
+}
+
+.save-button {
+    padding:6px 12px;
+    font-weight:bold;
+    border-radius:6px;
+    border:none;
+    background:#005a9c;
+    color:#fff;
+    cursor:pointer;
+}
+
+.custom-only {
+    display:flex;
+    flex-direction:column;
+    gap:6px;
+}


### PR DESCRIPTION
## Summary
- overhaul options page with modern bento style layout
- add theme selector (Classic, Light, Custom) and custom design controls
- show a right-side sidebar preview that reflects setting changes
- implement logic in `options.js` to save new options and update preview
- add stylesheet for the new interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686551d12acc83268a076c22f358870a