### PR TITLE
Enhance sidebar preview and style controls

### DIFF
--- a/FENNEC/options.html
+++ b/FENNEC/options.html
@@ -75,6 +75,13 @@
                 <label>Box background
                     <input type="color" id="sidebar-box-color">
                 </label>
+                <label>Box title size
+                    <input type="number" id="box-title-size" min="12" max="22" step="1">
+                </label>
+                <label><input type="checkbox" id="box-title-bold"> Bold box title</label>
+                <label>Box title color
+                    <input type="color" id="box-title-color">
+                </label>
                 <label>Button color
                     <input type="color" id="button-color">
                 </label>
@@ -105,18 +112,39 @@
             <div id="corp-preview" class="sidebar-preview">
                 <div class="header">CORP MAIN</div>
                 <div class="white-box">
-                    <div class="line1">Example Corporation</div>
-                    <div class="line2">Formation Order</div>
-                    <div class="line3">Expedited</div>
+                    <div class="box-title">🏢</div>
+                    <div class="line1">EXAMPLE LLC</div>
+                    <div class="line2">CA • ID 123456789</div>
+                    <div class="line3">Formed Jan 01, 2020</div>
+                </div>
+                <div class="white-box">
+                    <div class="box-title">🕵️</div>
+                    <div class="line1">Example RA Inc.</div>
+                    <div class="line2">123 Street</div>
+                    <div class="line3">City, ST 12345</div>
+                </div>
+                <div class="white-box">
+                    <div class="box-title">👥</div>
+                    <div class="line1">John Doe</div>
+                    <div class="line2">Jane Roe</div>
                 </div>
                 <button class="example-button">Button</button>
             </div>
             <div id="amend-preview" class="sidebar-preview">
                 <div class="header">LLC AMENDMENT</div>
                 <div class="white-box">
-                    <div class="line1">Sample LLC</div>
-                    <div class="line2">Amendment Order</div>
-                    <div class="line3">Standard</div>
+                    <div class="box-title">🏢</div>
+                    <div class="line1">EXAMPLE LLC</div>
+                    <div class="line2">CA • ID 123456789</div>
+                </div>
+                <div class="white-box">
+                    <div class="box-title">🕵️</div>
+                    <div class="line1">Example RA Inc.</div>
+                    <div class="line2">City, ST 12345</div>
+                </div>
+                <div class="white-box">
+                    <div class="box-title">📝</div>
+                    <div class="line1">Amendment: change name</div>
                 </div>
                 <button class="example-button">Button</button>
             </div>

--- a/FENNEC/options.js
+++ b/FENNEC/options.js
@@ -22,6 +22,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const line3SizeInput = document.getElementById("line3-size");
     const line3Bold = document.getElementById("line3-bold");
     const line3ColorInput = document.getElementById("line3-color");
+    const boxTitleSizeInput = document.getElementById("box-title-size");
+    const boxTitleBold = document.getElementById("box-title-bold");
+    const boxTitleColorInput = document.getElementById("box-title-color");
     const buttonColorInput = document.getElementById("button-color");
     const buttonTextColorInput = document.getElementById("button-text-color");
     const buttonRadiusInput = document.getElementById("button-radius");
@@ -58,6 +61,9 @@ document.addEventListener("DOMContentLoaded", () => {
             p.style.setProperty("--line3-size", `${line3SizeInput.value}px`);
             p.style.setProperty("--line3-bold", line3Bold.checked ? '700' : '400');
             p.style.setProperty("--line3-color", line3ColorInput.value);
+            p.style.setProperty("--box-title-size", `${boxTitleSizeInput.value}px`);
+            p.style.setProperty("--box-title-bold", boxTitleBold.checked ? '700' : '400');
+            p.style.setProperty("--box-title-color", boxTitleColorInput.value);
             p.style.setProperty("--button-color", buttonColorInput.value);
             p.style.setProperty("--button-text-color", buttonTextColorInput.value);
             p.style.setProperty("--button-radius", `${buttonRadiusInput.value}px`);
@@ -86,6 +92,9 @@ document.addEventListener("DOMContentLoaded", () => {
         line3Size: 13,
         line3Bold: false,
         line3Color: "#ffffff",
+        boxTitleSize: 16,
+        boxTitleBold: true,
+        boxTitleColor: "#ffffff",
         buttonColor: "#333333",
         buttonTextColor: "#ffffff",
         buttonRadius: 6,
@@ -114,6 +123,9 @@ document.addEventListener("DOMContentLoaded", () => {
         line3SizeInput.value = parseInt(opts.line3Size,10) || 13;
         line3Bold.checked = Boolean(opts.line3Bold);
         line3ColorInput.value = opts.line3Color || '#ffffff';
+        boxTitleSizeInput.value = parseInt(opts.boxTitleSize,10) || 16;
+        boxTitleBold.checked = Boolean(opts.boxTitleBold);
+        boxTitleColorInput.value = opts.boxTitleColor || '#ffffff';
         buttonColorInput.value = opts.buttonColor || '#333333';
         buttonTextColorInput.value = opts.buttonTextColor || '#ffffff';
         buttonRadiusInput.value = parseInt(opts.buttonRadius,10) || 6;
@@ -144,6 +156,9 @@ document.addEventListener("DOMContentLoaded", () => {
             line3SizeInput.value = 13;
             line3Bold.checked = false;
             line3ColorInput.value = '#ffffff';
+            boxTitleSizeInput.value = 16;
+            boxTitleBold.checked = true;
+            boxTitleColorInput.value = '#ffffff';
             buttonColorInput.value = '#333333';
             buttonTextColorInput.value = '#ffffff';
             buttonRadiusInput.value = 6;
@@ -167,6 +182,9 @@ document.addEventListener("DOMContentLoaded", () => {
             line3SizeInput.value = 13;
             line3Bold.checked = false;
             line3ColorInput.value = '#000000';
+            boxTitleSizeInput.value = 16;
+            boxTitleBold.checked = true;
+            boxTitleColorInput.value = '#000000';
             buttonColorInput.value = '#005a9c';
             buttonTextColorInput.value = '#ffffff';
             buttonRadiusInput.value = 6;
@@ -201,6 +219,9 @@ document.addEventListener("DOMContentLoaded", () => {
             line3Size: parseInt(line3SizeInput.value,10) || 13,
             line3Bold: line3Bold.checked,
             line3Color: line3ColorInput.value,
+            boxTitleSize: parseInt(boxTitleSizeInput.value,10) || 16,
+            boxTitleBold: boxTitleBold.checked,
+            boxTitleColor: boxTitleColorInput.value,
             buttonColor: buttonColorInput.value,
             buttonTextColor: buttonTextColorInput.value,
             buttonRadius: parseInt(buttonRadiusInput.value,10) || 6,
@@ -216,9 +237,9 @@ document.addEventListener("DOMContentLoaded", () => {
     [widthInput, fontSizeSelect, fontSelect, bgColorInput, boxColorInput,
      headerFontSizeInput, headerBgColorInput, headerTextColorInput,
      line1SizeInput, line1ColorInput, line2SizeInput, line2ColorInput,
-     line3SizeInput, line3ColorInput, buttonColorInput, buttonTextColorInput,
-     buttonRadiusInput].forEach(el => el.addEventListener("input", updatePreview));
-    [headerBold, line1Bold, line2Bold, line3Bold].forEach(el => el.addEventListener('change', updatePreview));
+     line3SizeInput, line3ColorInput, boxTitleSizeInput, boxTitleColorInput,
+     buttonColorInput, buttonTextColorInput, buttonRadiusInput].forEach(el => el.addEventListener("input", updatePreview));
+    [headerBold, line1Bold, line2Bold, line3Bold, boxTitleBold].forEach(el => el.addEventListener('change', updatePreview));
     themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
     iconSetSelect.addEventListener('change', updatePreview);
     saveBtn.addEventListener("click", () => { save(); updatePreview(); });

--- a/FENNEC/styles/options.css
+++ b/FENNEC/styles/options.css
@@ -54,6 +54,9 @@ label {
     --line3-size:13px;
     --line3-bold:400;
     --line3-color:#ffffff;
+    --box-title-size:16px;
+    --box-title-bold:700;
+    --box-title-color:#ffffff;
     --button-color:#333333;
     --button-radius:6px;
     --button-text-color:#ffffff;
@@ -84,6 +87,16 @@ label {
     border-radius:4px;
     text-align:left;
     font-size:13px;
+    position:relative;
+}
+
+.sidebar-preview .box-title {
+    position:absolute;
+    top:4px;
+    right:6px;
+    font-size:var(--box-title-size);
+    font-weight:var(--box-title-bold);
+    color:var(--box-title-color);
 }
 
 .sidebar-preview .line1 { font-size:var(--line1-size); font-weight:var(--line1-bold); color:var(--line1-color); }


### PR DESCRIPTION
## Summary
- add box title styling options to options page
- show detailed sidebar previews for CORP MAIN and LLC AMENDMENT
- support new style variables in preview CSS
- store and apply box title preferences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686555cad2988326922959c54dd092e4