### PR TITLE
Add Review Mode toggle to popup

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 - Added quick resolve field below the Issue summary in Gmail.
+- Review Mode can now be toggled directly from the extension popup.
 - Sidebar design can now be customized from the Options page, including font size,
   font family and colors.
 - The Options page shows a live sidebar preview and Bento Mode has been removed.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -212,7 +212,7 @@ GENERAL FEATURES:
 3. Enable **Developer mode** (toggle in the top right).
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
-5. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode.
+5. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode. You can also toggle Review Mode directly from the extension popup.
 
 
 ## Local Mistral integration

--- a/FENNEC/popup.html
+++ b/FENNEC/popup.html
@@ -13,6 +13,10 @@
     <input type="checkbox" id="extension-toggle">
     <label for="extension-toggle">Enable FENNEC</label>
   </div>
+  <div id="review-wrapper" style="margin-top:8px; display:flex; align-items:center;">
+    <input type="checkbox" id="review-toggle" style="margin-right:8px;">
+    <label for="review-toggle">Review Mode</label>
+  </div>
   <button id="options-btn" style="margin-top:8px; width:100%;">Go to Options</button>
   <script src="popup.js"></script>
 </body>

--- a/FENNEC/popup.js
+++ b/FENNEC/popup.js
@@ -1,33 +1,37 @@
 // Handles enable/disable toggle and provides a quick link to Options
 const toggle = document.getElementById("extension-toggle");
 const optionsBtn = document.getElementById("options-btn");
+const reviewToggle = document.getElementById("review-toggle");
 
 function loadState() {
-    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+    chrome.storage.local.get({ extensionEnabled: true, fennecReviewMode: false }, ({ extensionEnabled, fennecReviewMode }) => {
         toggle.checked = Boolean(extensionEnabled);
+        reviewToggle.checked = Boolean(fennecReviewMode);
     });
 }
 
 function saveState() {
-    chrome.storage.local.set({ extensionEnabled: toggle.checked }, () => {
-        const urls = [
-            "https://mail.google.com/*",
-            "https://*.incfile.com/incfile/order/detail/*",
-            "https://*.incfile.com/storage/incfile/*",
-            "https://tools.usps.com/*"
-        ];
+    chrome.storage.local.set({ extensionEnabled: toggle.checked, fennecReviewMode: reviewToggle.checked }, () => {
+        chrome.storage.sync.set({ fennecReviewMode: reviewToggle.checked }, () => {
+            const urls = [
+                "https://mail.google.com/*",
+                "https://*.incfile.com/incfile/order/detail/*",
+                "https://*.incfile.com/storage/incfile/*",
+                "https://tools.usps.com/*"
+            ];
 
-        chrome.tabs.query({ url: urls }, tabs => {
-            tabs.forEach(tab => {
-                chrome.tabs.sendMessage(
-                    tab.id,
-                    { action: "fennecToggle", enabled: toggle.checked },
-                    () => {
-                        if (chrome.runtime.lastError) {
-                            chrome.tabs.reload(tab.id);
+            chrome.tabs.query({ url: urls }, tabs => {
+                tabs.forEach(tab => {
+                    chrome.tabs.sendMessage(
+                        tab.id,
+                        { action: "fennecToggle", enabled: toggle.checked },
+                        () => {
+                            if (chrome.runtime.lastError) {
+                                chrome.tabs.reload(tab.id);
+                            }
                         }
-                    }
-                );
+                    );
+                });
             });
         });
     });
@@ -36,5 +40,6 @@ function saveState() {
 document.addEventListener("DOMContentLoaded", () => {
     loadState();
     toggle.addEventListener("change", saveState);
+    reviewToggle.addEventListener("change", saveState);
     optionsBtn.addEventListener("click", () => chrome.runtime.openOptionsPage());
 });


### PR DESCRIPTION
## Summary
- add a Review Mode checkbox in `popup.html`
- update `popup.js` to load and save the Review Mode preference
- mention popup toggle in README installation steps
- note the new feature in CHANGELOG

## Testing
- `npm test --silent --prefix FENNEC`

------
https://chatgpt.com/codex/tasks/task_e_686560d40174832693effb612c3f1ff3