### PR TITLE
Add Fraud tracker XRAY support

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Diagnose overlay now displays all child orders instead of only the first three.
 - Added Dev Mode. The Mistral chat box, FILE and REFRESH buttons now appear only when Dev Mode is enabled.
 - Added quick resolve field below the Issue summary in Gmail.
+- Sidebar now loads on the Fraud tracker page and auto-enables Review Mode.
+  Order numbers show an 🩻 icon that runs XRAY starting with that order.
 - Review Mode can now be toggled directly from the extension popup.
 - Sidebar design can now be customized from the Options page, including font size,
   font family and colors.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -197,6 +197,7 @@ GENERAL FEATURES:
 - RA and VA tags display in the COMPANY box. If the Registered Agent Service shows an expiration date in the past, the RA tag turns yellow and reads **EXPIRED**.
 - 🩺 DIAGNOSE overlay lists hold orders from the Family Tree and now displays all child orders.
 - When the sidebar is opened manually in Gmail or Adyen, it starts empty and only shows the action buttons. Order details appear after using SEARCH, DNA or XRAY.
+- Visiting the Fraud tracker in DB automatically opens the sidebar in Review Mode and adds 🩻 XRAY icons next to each order number.
 
 ## Known limitations
 - The scripts rely on the browser DOM provided by Chrome.

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -1,0 +1,114 @@
+(function() {
+    chrome.storage.local.get({ extensionEnabled: true, lightMode: false }, opts => {
+        if (!opts.extensionEnabled) return;
+        if (opts.lightMode) {
+            document.body.classList.add('fennec-light-mode');
+        } else {
+            document.body.classList.remove('fennec-light-mode');
+        }
+        chrome.storage.local.set({ fennecReviewMode: true });
+        chrome.storage.sync.set({ fennecReviewMode: true });
+
+        function injectSidebar() {
+            if (document.getElementById('copilot-sidebar')) return;
+            const sidebar = document.createElement('div');
+            sidebar.id = 'copilot-sidebar';
+            sidebar.innerHTML = `
+                <div class="copilot-header">
+                    <div class="copilot-title">
+                        <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (BETA)" />
+                        <span>FENNEC (BETA)</span>
+                    </div>
+                    <button id="copilot-close">✕</button>
+                </div>
+                <div class="copilot-body" id="copilot-body-content">
+                    <div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>
+                    <div id="review-mode-label" class="review-mode-label" style="margin-top:4px; text-align:center; font-size:11px;">REVIEW MODE</div>
+                </div>`;
+            document.body.appendChild(sidebar);
+            chrome.storage.sync.get({
+                sidebarFontSize: 13,
+                sidebarFont: "'Inter', sans-serif",
+                sidebarBgColor: '#212121',
+                sidebarBoxColor: '#2e2e2e'
+            }, o => applySidebarDesign(sidebar, o));
+            const closeBtn = sidebar.querySelector('#copilot-close');
+            if (closeBtn) closeBtn.onclick = () => sidebar.remove();
+        }
+
+        function runXray(orderId) {
+            const dbUrl = `https://db.incfile.com/incfile/order/detail/${orderId}`;
+            const adyenUrl = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
+            chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true });
+            setTimeout(() => {
+                chrome.runtime.sendMessage({ action: 'openTab', url: adyenUrl, refocus: true, active: true });
+            }, 1000);
+        }
+
+        function addXrayIcon(el, orderId) {
+            if (el.dataset.xrayInjected) return;
+            el.dataset.xrayInjected = '1';
+            const btn = document.createElement('span');
+            btn.textContent = '🩻';
+            btn.className = 'copilot-xray';
+            btn.style.cursor = 'pointer';
+            btn.style.marginLeft = '4px';
+            btn.title = 'XRAY';
+            btn.addEventListener('click', e => {
+                e.preventDefault();
+                runXray(orderId);
+            });
+            el.insertAdjacentElement('afterend', btn);
+        }
+
+        function scanOrders() {
+            const anchors = Array.from(document.querySelectorAll('a[href*="/order/detail/"]'));
+            anchors.forEach(a => {
+                const m = a.href.match(/order\/detail\/(\d+)/);
+                if (m) addXrayIcon(a, m[1]);
+            });
+            const re = /22\d{10}/g;
+            const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+            const nodes = [];
+            while (walker.nextNode()) nodes.push(walker.currentNode);
+            nodes.forEach(node => {
+                const text = node.textContent;
+                if (!re.test(text)) return;
+                const frag = document.createDocumentFragment();
+                let last = 0;
+                text.replace(re, (match, idx) => {
+                    frag.appendChild(document.createTextNode(text.slice(last, idx)));
+                    const span = document.createElement('span');
+                    span.textContent = match;
+                    addXrayIcon(span, match);
+                    frag.appendChild(span);
+                    last = idx + match.length;
+                });
+                frag.appendChild(document.createTextNode(text.slice(last)));
+                node.parentNode.replaceChild(frag, node);
+            });
+        }
+
+        function loadSummary() {
+            const body = document.getElementById('copilot-body-content');
+            if (!body) return;
+            chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null }, ({ sidebarDb }) => {
+                if (Array.isArray(sidebarDb) && sidebarDb.length) {
+                    body.innerHTML = sidebarDb.join('');
+                    attachCommonListeners(body);
+                }
+            });
+        }
+
+        injectSidebar();
+        scanOrders();
+        loadSummary();
+
+        new MutationObserver(scanOrders).observe(document.body, { childList: true, subtree: true });
+        chrome.storage.onChanged.addListener((changes, area) => {
+            if (area === 'local' && (changes.sidebarDb || changes.sidebarOrderId)) {
+                loadSummary();
+            }
+        });
+    });
+})();

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -57,6 +57,20 @@
     },
     {
       "matches": [
+        "https://db.incfile.com/order-tracker/orders/fraud*"
+      ],
+      "all_frames": true,
+      "js": [
+        "core/utils.js",
+        "environments/db/tracker_fraud.js"
+      ],
+      "css": [
+        "styles/sidebar.css",
+        "styles/sidebar_light.css"
+      ]
+    },
+    {
+      "matches": [
         "https://tools.usps.com/zip-code-lookup.htm*"
       ],
       "js": [


### PR DESCRIPTION
## Summary
- load sidebar on Fraud tracker page with Review Mode enabled
- inject 🩻 XRAY icons next to order numbers to open DB then Adyen
- document Fraud tracker behaviour in README
- note new feature in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68656e54ba04832688ea21e599be9d48