### PR TITLE
Improve Gmail quick resolve UI

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -30,6 +30,9 @@
 
 - Quick resolve now reuses an existing DB tab when available and displays the
   completion message inside the Gmail sidebar instead of using a popup.
+- Quick resolve removes the input after posting your comment and shows it below
+  the Issue summary. If the issue was active, the status tag updates to
+  **RESOLVED**.
 
 - Quick Summary no longer auto-expands on Annual Report orders and the
   Family Tree panel loads automatically.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -53,6 +53,8 @@ MAIN (BUSINESS FORMATION ORDERS: SILVER, GOLD, PLATINUM)
          - Comment input and **COMMENT & RESOLVE** button.
       Quick resolve field under Issue summary
       Reuses any open DB tab for comments and resolves the issue only if active
+      The comment box disappears after submission showing your comment and a
+      success message. Resolving automatically updates the tag to RESOLVED.
       (Dev Mode) End: [🔄 REFRESH] button centered.
 
 MISC (ALL NON-BUSINESS FORMATION ORDERS)

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2066,7 +2066,13 @@
                 save.click();
                 sessionStorage.removeItem('fennecAutoComment');
                 sessionStorage.setItem('fennecAddComment', comment);
-                chrome.storage.local.set({ fennecQuickResolveDone: Date.now() });
+                chrome.storage.local.set({
+                    fennecQuickResolveDone: {
+                        time: Date.now(),
+                        resolved: true,
+                        comment
+                    }
+                });
                 chrome.runtime.sendMessage({ action: 'refocusTab' });
             } else {
                 setTimeout(fillComment, 500);
@@ -2093,7 +2099,13 @@
             if (ta && add) {
                 ta.value = comment;
                 add.click();
-                chrome.storage.local.set({ fennecQuickResolveDone: Date.now() });
+                chrome.storage.local.set({
+                    fennecQuickResolveDone: {
+                        time: Date.now(),
+                        resolved: false,
+                        comment
+                    }
+                });
                 chrome.runtime.sendMessage({ action: 'refocusTab' });
             } else {
                 setTimeout(fill, 500);

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1359,9 +1359,24 @@
                 window.location.reload();
             }
             if (area === 'local' && changes.fennecQuickResolveDone) {
+                const data = changes.fennecQuickResolveDone.newValue || {};
                 chrome.storage.local.remove('fennecQuickResolveDone');
                 const box = document.getElementById('issue-summary-box');
                 if (box) {
+                    const commentInput = document.getElementById('issue-comment-input');
+                    const resolveBtn = document.getElementById('issue-resolve-btn');
+                    if (commentInput) commentInput.remove();
+                    if (resolveBtn) resolveBtn.remove();
+                    if (data.comment) {
+                        let c = document.getElementById('quick-resolve-comment-text');
+                        if (!c) {
+                            c = document.createElement('div');
+                            c.id = 'quick-resolve-comment-text';
+                            c.className = 'quick-resolve-comment-text';
+                            box.appendChild(c);
+                        }
+                        c.textContent = data.comment;
+                    }
                     let msg = document.getElementById('quick-resolve-confirm');
                     if (!msg) {
                         msg = document.createElement('div');
@@ -1373,6 +1388,13 @@
                     msg.textContent = 'Issue updated successfully.';
                     msg.style.display = 'block';
                     setTimeout(() => { if (msg) msg.style.display = 'none'; }, 3000);
+                    if (data.resolved) {
+                        const label = document.getElementById('issue-status-label');
+                        if (label) {
+                            label.textContent = 'RESOLVED';
+                            label.className = 'issue-status-label issue-status-resolved';
+                        }
+                    }
                 }
             }
         });

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -196,6 +196,19 @@
     box-sizing: border-box;
 }
 
+.quick-resolve-comment-text {
+    width: calc(100% - 8px);
+    margin: 6px 4px 0;
+    padding: 4px;
+    border-radius: 4px;
+    border: 1px solid #888;
+    box-sizing: border-box;
+    text-align: left;
+    word-break: break-word;
+    background: #fff;
+    color: #000;
+}
+
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
     background-color: var(--sb-box-bg);

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -143,6 +143,12 @@
     color: #000 !important;
 }
 
+.fennec-light-mode .quick-resolve-comment-text {
+    border: 1px solid #777;
+    background: #fff;
+    color: #000;
+}
+
 /* Use inverted Fennec icon in light mode */
 .fennec-light-mode .copilot-icon,
 .fennec-light-mode #fennec-floating-icon,


### PR DESCRIPTION
## Summary
- show comment text and success message after quick resolving an issue
- switch issue status tag to RESOLVED when resolving from Gmail
- carry quick resolve details via `fennecQuickResolveDone`
- document new behaviour in README and CHANGELOG
- add styling for the displayed comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686574a1ebf483268f4574e4170b8a29