### PR TITLE
Add SOS search toggle for company box

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -197,6 +197,7 @@ GENERAL FEATURES:
 - Clicking COMPANY NAME opens the SOS search, injects the name and hits search.
 - Clicking the STATE ID in the sidebar opens the Coda Knowledge Base in a popup window covering about 70% of the page.
 - RA and VA tags display in the COMPANY box. If the Registered Agent Service shows an expiration date in the past, the RA tag turns yellow and reads **EXPIRED**.
+- A magnifier icon on the COMPANY box toggles a form with inputs to run SOS name or ID searches using custom parameters.
 - 🩺 DIAGNOSE overlay lists hold orders from the Family Tree and now displays all child orders.
 - When the sidebar is opened manually in Gmail or Adyen, it starts empty and only shows the action buttons. Order details appear after using SEARCH, DNA or XRAY.
 - Visiting the Fraud tracker in DB automatically opens the sidebar in Review Mode and adds 🩻 XRAY icons next to each order number.

--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -209,5 +209,51 @@ function attachCommonListeners(rootEl) {
             });
         });
     }
+
+    rootEl.querySelectorAll('.company-search-toggle').forEach(el => {
+        el.addEventListener('click', () => {
+            const box = el.closest('.white-box');
+            if (box && typeof toggleCompanySearch === 'function') {
+                toggleCompanySearch(box);
+            }
+        });
+    });
 }
+
+function toggleCompanySearch(box) {
+    if (!box) return;
+    const mode = box.dataset.mode || 'info';
+    const state = box.dataset.state || '';
+    if (mode === 'search') {
+        box.innerHTML = box.dataset.infoHtml || '';
+        box.dataset.mode = 'info';
+        attachCommonListeners(box);
+        return;
+    }
+    box.dataset.infoHtml = box.innerHTML;
+    box.dataset.mode = 'search';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.placeholder = 'Search name';
+    const idInput = document.createElement('input');
+    idInput.type = 'text';
+    idInput.placeholder = 'Search ID';
+    const form = document.createElement('div');
+    form.className = 'company-search-form';
+    form.appendChild(nameInput);
+    form.appendChild(idInput);
+    box.innerHTML = '';
+    box.appendChild(form);
+    const doSearch = (type) => {
+        const q = type === 'name' ? nameInput.value.trim() : idInput.value.trim();
+        if (!q) return;
+        if (typeof buildSosUrl !== 'function') return;
+        const url = buildSosUrl(state, null, type);
+        if (!url) return;
+        chrome.runtime.sendMessage({ action: 'sosSearch', url, query: q, searchType: type });
+    };
+    nameInput.addEventListener('keydown', e => { if (e.key === 'Enter') doSearch('name'); });
+    idInput.addEventListener('keydown', e => { if (e.key === 'Enter') doSearch('id'); });
+}
+window.toggleCompanySearch = toggleCompanySearch;
 

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -657,6 +657,7 @@
         const sep = base.includes('?') ? '&' : '?';
         return base + sep + 'q=' + encodeURIComponent(query);
     }
+    window.buildSosUrl = buildSosUrl;
 
 
     function isValidField(text) {
@@ -1560,9 +1561,11 @@
                 `<div><span class="${raClass}">RA: ${raExpired ? "EXPIRED" : (hasRA ? "Sí" : "No")}</span> ` +
                 `<span class="${vaClass}">VA: ${hasVA ? "Sí" : "No"}</span></div>`
             );
+            const searchIcon = '<span class="company-search-toggle">🔍</span>';
+            const stateAttr = company.state ? ` data-state="${escapeHtml(company.state)}"` : '';
             const compSection = reviewMode
-                ? `<div class="white-box" style="margin-bottom:10px">${companyLines.join('').trim()}</div>`
-                : `<div class="section-label">COMPANY:</div><div class="white-box" style="margin-bottom:10px">${companyLines.join('').trim()}</div>`;
+                ? `<div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}${searchIcon}</div>`
+                : `<div class="section-label">COMPANY:</div><div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}${searchIcon}</div>`;
             if (companyLines.length) {
                 html += compSection;
                 dbSections.push(compSection);

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -98,6 +98,7 @@
                 const sep = base.includes('?') ? '&' : '?';
                 return base + sep + 'q=' + encodeURIComponent(query);
             }
+            window.buildSosUrl = buildSosUrl;
 
         function applyPaddingToMainPanels() {
             const candidates = [

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -222,6 +222,25 @@
     position: relative;
 }
 
+.company-search-toggle {
+    position: absolute;
+    bottom: 4px;
+    right: 6px;
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.company-search-form {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.company-search-form input {
+    padding: 4px;
+    font-size: 12px;
+}
+
 #copilot-sidebar .box-title {
     position: absolute;
     top: 6px;

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -129,6 +129,16 @@
     color: #000;
 }
 
+.fennec-light-mode .company-search-toggle {
+    color: #000;
+}
+
+.fennec-light-mode .company-search-form input {
+    background: #fff;
+    color: #000;
+    border: 1px solid #777;
+}
+
 /* Ensure header icon stays visible */
 .fennec-light-mode #copilot-close {
     color: #fff;


### PR DESCRIPTION
## Summary
- add search toggle icon to company summary white box
- implement toggleCompanySearch helper and hook into common listeners
- expose buildSosUrl globally
- style search icon and inputs for light & dark themes
- document new SOS search toggle in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865766f13148326b66d4757d1c394cf