### PR TITLE
Add inline SOS search toggle

### DIFF
--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -244,6 +244,10 @@ function toggleCompanySearch(box) {
     form.appendChild(idInput);
     box.innerHTML = '';
     box.appendChild(form);
+    const searchIcon = document.createElement('span');
+    searchIcon.className = 'company-search-toggle';
+    searchIcon.textContent = '🔍';
+    box.appendChild(searchIcon);
     const doSearch = (type) => {
         const q = type === 'name' ? nameInput.value.trim() : idInput.value.trim();
         if (!q) return;
@@ -254,6 +258,7 @@ function toggleCompanySearch(box) {
     };
     nameInput.addEventListener('keydown', e => { if (e.key === 'Enter') doSearch('name'); });
     idInput.addEventListener('keydown', e => { if (e.key === 'Enter') doSearch('id'); });
+    attachCommonListeners(box);
 }
 window.toggleCompanySearch = toggleCompanySearch;
 

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1553,7 +1553,8 @@
             if (company.formationDate && company.formationDate.toLowerCase() !== 'n/a') {
                 highlight.push(`<div><b>${escapeHtml(company.formationDate)}</b></div>`);
             }
-            companyLines.push(`<div class="company-summary-highlight">${highlight.join('')}</div>`);
+            const searchIcon = '<span class="company-search-toggle">🔍</span>';
+            companyLines.push(`<div class="company-summary-highlight">${highlight.join('')}${searchIcon}</div>`);
             companyLines.push(`<div>${renderKb(company.state)}</div>`);
             companyLines.push(addrHtml);
             companyLines.push(`<div class="company-purpose">${renderCopy(company.purpose)}</div>`);
@@ -1561,11 +1562,10 @@
                 `<div><span class="${raClass}">RA: ${raExpired ? "EXPIRED" : (hasRA ? "Sí" : "No")}</span> ` +
                 `<span class="${vaClass}">VA: ${hasVA ? "Sí" : "No"}</span></div>`
             );
-            const searchIcon = '<span class="company-search-toggle">🔍</span>';
             const stateAttr = company.state ? ` data-state="${escapeHtml(company.state)}"` : '';
             const compSection = reviewMode
-                ? `<div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}${searchIcon}</div>`
-                : `<div class="section-label">COMPANY:</div><div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}${searchIcon}</div>`;
+                ? `<div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}</div>`
+                : `<div class="section-label">COMPANY:</div><div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}</div>`;
             if (companyLines.length) {
                 html += compSection;
                 dbSections.push(compSection);

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -239,6 +239,7 @@
 .company-search-form input {
     padding: 4px;
     font-size: 12px;
+    color: #000;
 }
 
 #copilot-sidebar .box-title {
@@ -398,6 +399,7 @@
     border-radius: 4px;
     padding: 4px;
     margin-bottom: 6px;
+    position: relative;
 }
 #copilot-sidebar .white-box .company-summary-highlight,
 #copilot-sidebar .white-box .company-summary-highlight * {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -99,6 +99,7 @@
     border-radius: 4px;
     padding: 4px;
     margin-bottom: 6px;
+    position: relative;
 }
 .fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight,
 .fennec-light-mode #copilot-sidebar .white-box .company-summary-highlight * {


### PR DESCRIPTION
## Summary
- move magnifier icon inside the light gray company summary box
- keep icon visible in search mode
- make search inputs always show black text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865791bfbd08326a3b7a665fcfe0a0f