### PR TITLE
Fix light box search color and SOS field targeting

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -403,12 +403,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                             const patterns = type === "id"
                                 ? ["id", "number", "document", "control", "filing", "account"]
                                 : ["name", "business", "entity", "organization", "company", "keyword", "search"];
+                            const skip = ["login", "email", "user", "password"];
                             let attempts = 10;
                             const run = () => {
-                                const inputs = Array.from(document.querySelectorAll("input,textarea"));
+                                const inputs = Array.from(document.querySelectorAll("input[type='text'],input[type='search'],input:not([type]),textarea"));
                                 const field = inputs.find(i => {
+                                    if (i.type === 'hidden' || !(i.offsetWidth || i.offsetHeight || i.getClientRects().length)) return false;
                                     const attrs = (i.name || "") + " " + (i.id || "") + " " + (i.placeholder || "") + " " + (i.getAttribute("aria-label") || "");
                                     const txt = attrs.toLowerCase();
+                                    if (skip.some(p => txt.includes(p))) return false;
                                     return patterns.some(p => txt.includes(p));
                                 });
                                 if (field) {

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -239,7 +239,7 @@
 .company-search-form input {
     padding: 4px;
     font-size: 12px;
-    color: #000;
+    color: #000 !important;
 }
 
 #copilot-sidebar .box-title {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -136,7 +136,7 @@
 
 .fennec-light-mode .company-search-form input {
     background: #fff;
-    color: #000;
+    color: #000 !important;
     border: 1px solid #777;
 }
 


### PR DESCRIPTION
## Summary
- ensure company search inputs use black text in both themes
- refine SOS search field detection logic to avoid wrong inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657b5e0e6c8326a0bc344bbc130686