### PR TITLE
Fix search box text color

### DIFF
--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -241,6 +241,10 @@
     font-size: 12px;
     color: #000 !important;
 }
+/* Ensure text stays black even with inherited white-box color */
+#copilot-sidebar .white-box .company-search-form input {
+    color: #000 !important;
+}
 
 #copilot-sidebar .box-title {
     position: absolute;


### PR DESCRIPTION
## Summary
- ensure search inputs use black text even inside white box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657f454318832693691bf5a5af5ae4