### PR TITLE
Add duplicate order detection

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - The payment step logs the dropdown selector and value before clicking **Continue** so you can confirm **Client Account** is selected.
+- Family Tree detects duplicate orders in review, processing or hold and adds a ❌ icon to cancel and refund them.
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2132,6 +2132,15 @@
         }
     }
 
+    function processDuplicateCancel(id) {
+        if (!id) return;
+        const info = getBasicOrderInfo();
+        if (!info.orderId || String(info.orderId) !== String(id)) return;
+        chrome.storage.local.remove('fennecDupCancel');
+        startCancelProcedure();
+        chrome.storage.local.set({ fennecDupCancelDone: { orderId: id } });
+    }
+
     function openCodaSearch() {
         let overlay = document.getElementById('fennec-coda-overlay');
         if (overlay) overlay.remove();
@@ -2617,6 +2626,10 @@ chrome.storage.local.get({ fennecPendingComment: null }, ({ fennecPendingComment
     processPendingComment(fennecPendingComment);
 });
 
+chrome.storage.local.get({ fennecDupCancel: null }, ({ fennecDupCancel }) => {
+    processDuplicateCancel(fennecDupCancel);
+});
+
 const pendingNote = sessionStorage.getItem('fennecAddComment');
 if (pendingNote) {
     sessionStorage.removeItem('fennecAddComment');
@@ -2634,6 +2647,9 @@ chrome.storage.onChanged.addListener((changes, area) => {
     }
     if (area === 'local' && changes.fennecPendingComment) {
         processPendingComment(changes.fennecPendingComment.newValue);
+    }
+    if (area === 'local' && changes.fennecDupCancel) {
+        processDuplicateCancel(changes.fennecDupCancel.newValue);
     }
     if (area === 'local' && (changes.sidebarDb || changes.sidebarOrderId || changes.sidebarOrderInfo)) {
         const currentId = getBasicOrderInfo().orderId;

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -566,6 +566,12 @@
     text-decoration: underline;
 }
 
+#family-tree-orders .ft-cancel {
+    color: #f44336;
+    cursor: pointer;
+    margin-left: 4px;
+}
+
 @keyframes fennec-blink {
     0%, 50%, 100% { opacity: 1; }
     25%, 75% { opacity: 0; }


### PR DESCRIPTION
## Summary
- detect duplicate orders in the Family Tree
- add ❌ icon to cancel duplicate orders and update their labels
- trigger automatic cancel procedure when opening an order from the icon
- style cancel icon
- note the feature in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686580eba4a883269e86010d30e2cc0a