### PR TITLE
Fix CVV label parsing and clear summary behavior

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -137,3 +137,4 @@
 - Comment & Resolve in Gmail now reuses an open DB tab and only resolves when the issue is active.
 - DNA summary refreshes when returning focus to DB or Gmail so results from XRAY appear consistently.
 - XRAY now opens the Kount workflow page when a Kount link is present on the DB page.
+- CVV tags in DB SB Fraud Review correctly detect "Matches (M)" and the Fraud Review summary reappears after using CLEAR.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1848,9 +1848,15 @@
         }
         function formatCvv(text) {
             const t = (text || '').toLowerCase();
-            if (t.includes('matched')) { return { label: 'CVV: MATCH', result: 'green' }; }
-            if (t.includes('not matched')) { return { label: 'CVV: NO MATCH', result: 'purple' }; }
-            if (t.includes('not provided') || t.includes('not checked') || t.includes('error') || t.includes('not supplied') || t.includes('unknown')) { return { label: 'CVV: UNKNOWN', result: 'black' }; }
+            if ((/\bmatch(es|ed)?\b/.test(t) || /\(m\)/.test(t)) && !/not\s+match/.test(t)) {
+                return { label: 'CVV: MATCH', result: 'green' };
+            }
+            if (/not\s+match/.test(t) || /\(n\)/.test(t)) {
+                return { label: 'CVV: NO MATCH', result: 'purple' };
+            }
+            if (/not provided|not checked|error|not supplied|unknown/.test(t)) {
+                return { label: 'CVV: UNKNOWN', result: 'black' };
+            }
             return { label: 'CVV: UNKNOWN', result: 'black' };
         }
         function formatAvs(text) {

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -82,6 +82,8 @@
             btn.title = 'XRAY';
             btn.addEventListener('click', e => {
                 e.preventDefault();
+                const box = document.getElementById('fraud-summary-box');
+                if (box) box.remove();
                 runXray(orderId);
             });
             el.insertAdjacentElement('afterend', btn);
@@ -237,9 +239,9 @@
             }
             function formatCvv(t) {
                 t = (t || '').toLowerCase();
-                if (t.includes('matched')) return { label: 'CVV: MATCH', result: 'green' };
-                if (t.includes('not matched')) return { label: 'CVV: NO MATCH', result: 'purple' };
-                if (t.includes('not provided') || t.includes('not checked') || t.includes('error') || t.includes('not supplied') || t.includes('unknown')) return { label: 'CVV: UNKNOWN', result: 'black' };
+                if ((/\bmatch(es|ed)?\b/.test(t) || /\(m\)/.test(t)) && !/not\s+match/.test(t)) return { label: 'CVV: MATCH', result: 'green' };
+                if (/not\s+match/.test(t) || /\(n\)/.test(t)) return { label: 'CVV: NO MATCH', result: 'purple' };
+                if (/not provided|not checked|error|not supplied|unknown/.test(t)) return { label: 'CVV: UNKNOWN', result: 'black' };
                 return { label: 'CVV: UNKNOWN', result: 'black' };
             }
             function formatAvs(t) {
@@ -392,10 +394,13 @@
             chrome.storage.local.set({ sidebarDb: [], sidebarOrderId: null, sidebarOrderInfo: null, adyenDnaInfo: null, sidebarFreezeId: null });
             const db = document.getElementById('db-summary-section');
             const dna = document.getElementById('dna-summary');
+            const fraud = document.getElementById('fraud-summary-section');
             const issue = document.getElementById('issue-summary-box');
             if (db) db.innerHTML = '';
             if (dna) dna.innerHTML = '';
+            if (fraud) fraud.innerHTML = '';
             if (issue) { const content = issue.querySelector('#issue-summary-content'); const label = issue.querySelector('#issue-status-label'); if (content) content.innerHTML = 'No issue data yet.'; if (label) { label.textContent = ''; label.className = 'issue-status-label'; } issue.style.display = 'none'; }
+            insertFraudSummary();
         }
 
         injectSidebar();

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -951,13 +951,13 @@
 
             function formatCvv(text) {
                 const t = (text || '').toLowerCase();
-                if (t.includes('matched')) {
+                if ((/\bmatch(es|ed)?\b/.test(t) || /\(m\)/.test(t)) && !/not\s+match/.test(t)) {
                     return { label: 'CVV: MATCH', result: 'green' };
                 }
-                if (t.includes('not matched')) {
+                if (/not\s+match/.test(t) || /\(n\)/.test(t)) {
                     return { label: 'CVV: NO MATCH', result: 'purple' };
                 }
-                if (t.includes('not provided') || t.includes('not checked') || t.includes('error') || t.includes('not supplied') || t.includes('unknown')) {
+                if (/not provided|not checked|error|not supplied|unknown/.test(t)) {
                     return { label: 'CVV: UNKNOWN', result: 'black' };
                 }
                 return { label: 'CVV: UNKNOWN', result: 'black' };


### PR DESCRIPTION
## Summary
- improve CVV parsing across the extension
- remove Fraud Review summary when running XRAY
- restore Fraud Review summary when CLEAR is pressed
- document the fix in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68659cf61ea483268d5c70070065e96e