### PR TITLE
Implement misc family tree auto-open and improve duplicate cancel

### DIFF
--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -213,7 +213,11 @@ function attachCommonListeners(rootEl) {
                         e.preventDefault();
                         const id = a.dataset.id;
                         if (id) {
-                            chrome.runtime.sendMessage({ action: 'openTab', url: `${location.origin}/incfile/order/detail/${id}` });
+                            chrome.runtime.sendMessage({
+                                action: 'openOrReuseTab',
+                                url: `${location.origin}/incfile/order/detail/${id}`,
+                                active: false
+                            });
                         }
                     });
                 });
@@ -223,7 +227,11 @@ function attachCommonListeners(rootEl) {
                         if (!id) return;
                         if (!confirm('Cancel and refund order ' + id + '?')) return;
                         chrome.storage.local.set({ fennecDupCancel: id }, () => {
-                            chrome.runtime.sendMessage({ action: 'openActiveTab', url: `${location.origin}/incfile/order/detail/${id}` });
+                            chrome.runtime.sendMessage({
+                                action: 'openOrReuseTab',
+                                url: `${location.origin}/incfile/order/detail/${id}`,
+                                active: true
+                            });
                         });
                     });
                 });

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -9,6 +9,7 @@
     let initQuickSummary = null;
     let annualReportMode = false;
     let reinstatementMode = false;
+    let miscMode = false;
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
     let devMode = false;
@@ -58,7 +59,7 @@
                 attachCommonListeners(body);
                 updateReviewDisplay();
                 checkLastIssue(currentId);
-                if (annualReportMode) {
+                if (miscMode) {
                     setTimeout(autoOpenFamilyTree, 100);
                 }
             } else {
@@ -492,6 +493,7 @@
                         currentOrderTypeText = normalizeOrderType(rawType);
                         annualReportMode = /annual report/i.test(currentOrderTypeText);
                         reinstatementMode = /reinstat/i.test(currentOrderTypeText);
+                        miscMode = !/formation/i.test(currentOrderTypeText);
                         const frozen = sidebarFreezeId && sidebarFreezeId === currentId;
                         const hasStored = Array.isArray(sidebarDb) && sidebarDb.length && sidebarOrderId === currentId;
                         if (isStorage || (frozen && hasStored)) {
@@ -1726,7 +1728,7 @@
             initMistralChat();
             updateReviewDisplay();
             checkLastIssue(orderInfo.orderId);
-            if (annualReportMode) {
+            if (miscMode) {
                 setTimeout(autoOpenFamilyTree, 100);
             }
         }
@@ -2018,6 +2020,7 @@
             sessionStorage.removeItem('fennecCancelPending');
             cancelLink.click();
             selectCancelReason();
+            fillCancelDescription();
         }, 500);
     }
 
@@ -2025,11 +2028,17 @@
         const sel = document.querySelector('select');
         if (!sel) return setTimeout(selectCancelReason, 500);
         const opt = Array.from(sel.options)
-            .find(o => /client.*cancell?ation/i.test(o.textContent));
+            .find(o => /other/i.test(o.textContent));
         if (opt) {
             sel.value = opt.value;
             sel.dispatchEvent(new Event('change', { bubbles: true }));
         }
+    }
+
+    function fillCancelDescription() {
+        const ta = document.querySelector('textarea');
+        if (!ta) return setTimeout(fillCancelDescription, 500);
+        ta.value = 'DUPLICATE ORDER';
     }
 
     function formatDateLikeParent(text) {


### PR DESCRIPTION
## Summary
- open DB family tree links without creating duplicate tabs
- reuse existing tabs when canceling duplicate orders
- auto-open family tree for all miscellaneous orders
- prefill duplicate cancel reason and description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ab24eca48326ab3f50ece39a03b5