### PR TITLE
Add clipboard icon for addresses

### DIFF
--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -149,7 +149,7 @@
                 if (line1) lines.push(escapeHtml(line1));
                 if (line2) lines.push(escapeHtml(line2));
                 const esc = escapeHtml(addr);
-                return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${esc}">${lines.join('<br>')}</a><span class="copilot-usps" data-address="${esc}" title="USPS Lookup"> ✉️</span></span>`;
+                return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${esc}">${lines.join('<br>')}</a><span class="copilot-usps" data-address="${esc}" title="USPS Lookup"> ✉️</span><span class="copilot-copy-icon" data-copy="${esc}" title="Copy">⧉</span></span>`;
             }
 
             function buildCardMatchTag(info) {

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -697,7 +697,7 @@
         const escFull = escapeHtml(addr);
         const extra = isVA
             ? ` <span class="copilot-tag copilot-tag-green">VA</span>`
-            : `<span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span>`;
+            : `<span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span><span class="copilot-copy-icon" data-copy="${escFull}" title="Copy">⧉</span>`;
         return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${display}</a>${extra}</span>`;
     }
 
@@ -726,7 +726,7 @@
         if (!displayLines.length) return '';
         const full = [line1, line2].filter(Boolean).join(', ');
         const escFull = escapeHtml(full);
-        return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${displayLines.join('<br>')}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span></span>`;
+        return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${displayLines.join('<br>')}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span><span class="copilot-copy-icon" data-copy="${escFull}" title="Copy">⧉</span></span>`;
     }
 
     function formatExpiry(text) {

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -449,7 +449,7 @@
             if (rest) lines.push(rest);
             const display = lines.map(escapeHtml).join('<br>');
             const escFull = escapeHtml(addr);
-            return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${display}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span></span>`;
+            return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${display}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span><span class="copilot-copy-icon" data-copy="${escFull}" title="Copy">⧉</span></span>`;
         }
 
         // Format billing address into two lines and add USPS verification
@@ -487,7 +487,7 @@
             if (line1) lines.push(escapeHtml(line1));
             if (line2) lines.push(escapeHtml(line2));
             const escFull = escapeHtml(addr);
-            return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${lines.join('<br>')}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span></span>`;
+            return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${lines.join('<br>')}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span><span class="copilot-copy-icon" data-copy="${escFull}" title="Copy">⧉</span></span>`;
         }
 
         function normalizeAddr(a) {


### PR DESCRIPTION
## Summary
- add copy icon next to USPS lookup icon in Gmail
- show copy icon after USPS icon in DB sidebar
- allow copying addresses in Adyen billing display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ade802e883269dacc103318e243d