### PR TITLE
Add Kount summary extraction

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -137,4 +137,5 @@
 - Comment & Resolve in Gmail now reuses an open DB tab and only resolves when the issue is active.
 - DNA summary refreshes when returning focus to DB or Gmail so results from XRAY appear consistently.
 - XRAY now opens the Kount workflow page when a Kount link is present on the DB page.
+- Kount summary box displays email age, device location and Ekata results below DNA.
 - CVV tags in DB SB Fraud Review correctly detect "Matches (M)" and the Fraud Review summary reappears after using CLEAR.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -101,32 +101,36 @@ MAIN:
          - Line 4: CVV, AVS and DB match tags.
          - Line 5: Fraud scoring.
          - Line 6: Transaction table with totals.
-      2nd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
+      2nd box: KOUNT summary
+         - Email age, device location, VIP declines and Ekata results.
+      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
          - Same lines as the DB COMPANY box.
-      3rd box: CLIENT summary
+      4th box: CLIENT summary
          - Line 1: Client name and ID link.
          - Line 2: Role tags or NOT LISTED.
          - Line 3: Email and phone.
          - Line 4: Companies count and LTV.
-      4th box: BILLING summary
+      5th box: BILLING summary
          - Line 1: Cardholder name.
          - Line 2: Card type • last four digits • expiry.
          - Line 3: AVS result tag.
          - Line 4: Billing address.
-      5th box: Issue summary
+      6th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
    (Dev Mode) End: [🔄 REFRESH] button centered.
    GM:
       Title: [📧 SEARCH], [🧬 DNA] & [🩻 XRAY] buttons centered.
       1st box: ADYEN's DNA summary
-         - Same lines as DB ADYEN box.
-      2nd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
+      - Same lines as DB ADYEN box.
+      2nd box: KOUNT summary
+         - Email age, device location, VIP declines and Ekata results.
+      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
          - Same lines as DB COMPANY box.
-      3rd box: CLIENT summary
+      4th box: CLIENT summary
          - Same lines as DB CLIENT box.
-      4th box: BILLING summary
+      5th box: BILLING summary
          - Same lines as DB BILLING box.
-      5th box: Issue summary
+      6th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
    (Dev Mode) End: [🔄 REFRESH] button centered.
 
@@ -135,38 +139,44 @@ MISC:
       Title: FAMILY TREE display/collapse button (🌳), "ORDER SUMMARY"
       1st box: ADYEN's DNA summary (only if DNA or XRAY have been triggered)
          - Same lines as DB ADYEN box.
-      2nd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
+      2nd box: KOUNT summary
+         - Email age, device location, VIP declines and Ekata results.
+      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
          - Same lines as DB COMPANY box.
-      3rd box: CLIENT summary
+      4th box: CLIENT summary
          - Same lines as DB CLIENT box.
-      4th box: BILLING summary
+      5th box: BILLING summary
          - Same lines as DB BILLING box.
-      5th box: Issue summary
+      6th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
       (Dev Mode) End: [🔄 REFRESH] button centered.
    GM:
       Title: [📧 SEARCH], [🧬 DNA] & [🩻 XRAY] buttons centered.
       1st box: ADYEN's DNA summary (only if DNA or XRAY have been triggered)
          - Same lines as DB ADYEN box.
-      2nd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
+      2nd box: KOUNT summary
+         - Email age, device location, VIP declines and Ekata results.
+      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
          - Same lines as DB COMPANY box.
-      3rd box: CLIENT summary
+      4th box: CLIENT summary
          - Same lines as DB CLIENT box.
-      4th box: BILLING summary
+      5th box: BILLING summary
          - Same lines as DB BILLING box.
-      5th box: Issue summary
+      6th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
       (Dev Mode) End: [🔄 REFRESH] button centered.
    ADYEN:
       1st box: ADYEN's DNA summary (only if DNA or XRAY have been triggered)
          - Same lines as DB ADYEN box.
-      2nd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
+      2nd box: KOUNT summary
+         - Email age, device location, VIP declines and Ekata results.
+      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
          - Same lines as DB COMPANY box.
-      3rd box: CLIENT summary
+      4th box: CLIENT summary
          - Same lines as DB CLIENT box.
-      4th box: BILLING summary
+      5th box: BILLING summary
          - Same lines as DB BILLING box.
-      5th box: Issue summary
+      6th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
       (Dev Mode) End: [🔄 REFRESH] button centered.
 
@@ -191,6 +201,7 @@ ICONS/BUTTONS/FUNCTIONS:
    Focus returns to the original email once information is retrieved.
 🩻 XRAY: Runs SEARCH and DNA operations one after the other and opens the Kount workflow page when available.
    Focus also returns to the original email at the end.
+   A KOUNT summary box appears below DNA after the data is extracted.
 🤖 FILE: Automator that opens and fills the SOS filing process.
 
 GENERAL FEATURES:

--- a/FENNEC/dictionary.txt
+++ b/FENNEC/dictionary.txt
@@ -52,6 +52,7 @@ DNA Match Tag → Label indicating if Billing details agree with the DNA data
 Card Match Tag → Label showing if DB card details match the Adyen card info
 Transaction table → Colored summary of Adyen transactions
 Light Gray Tag → Label color used for Adyen DNA entries in Review Mode (light gray background with black text)
+Kount summary → Box showing email age, device location, VIP declines and Ekata results
 Knowledge Base overlay → Deprecated floating window that tried to show the Coda Knowledge Base over the DB page
 CVV → Card Verification Value result code
 AVS → Address Verification System result code

--- a/FENNEC/environments/kount/kount_launcher.js
+++ b/FENNEC/environments/kount/kount_launcher.js
@@ -1,0 +1,69 @@
+(function() {
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) return;
+        try {
+            function saveData(part) {
+                chrome.storage.local.get({ kountInfo: {} }, ({ kountInfo }) => {
+                    const updated = Object.assign({}, kountInfo, part);
+                    chrome.storage.local.set({ kountInfo: updated });
+                    console.log('[FENNEC Kount] Data saved', part);
+                });
+            }
+
+            const path = window.location.pathname;
+
+            function findVal(label) {
+                const cell = Array.from(document.querySelectorAll('table th, table td'))
+                    .find(el => el.textContent.trim() === label);
+                return cell && cell.nextElementSibling ? cell.nextElementSibling.textContent.trim() : '';
+            }
+
+            if (path.includes('/workflow/detail')) {
+                const run = () => {
+                    const emailAgeEl = document.querySelector('span[title*="email address was first seen"]');
+                    const emailAge = emailAgeEl ? emailAgeEl.textContent.trim() : '';
+                    const locEl = document.querySelector('th[title="Device Location"] + td span');
+                    const deviceLocation = locEl ? locEl.textContent.trim() : '';
+                    const ipEl = document.querySelector('th[title*="IP Address"] + td');
+                    const ip = ipEl ? ipEl.textContent.trim() : '';
+
+                    const vipBtn = Array.from(document.querySelectorAll('a,button'))
+                        .find(el => /VIP Lists/i.test(el.textContent));
+                    if (vipBtn) vipBtn.click();
+                    const declines = Array.from(document.querySelectorAll('#vip-lists tr'))
+                        .filter(row => row.querySelector('input[value="decline"]')?.checked)
+                        .map(row => {
+                            const label = row.querySelector('th')?.textContent.trim() || '';
+                            const valEl = row.querySelector('td.value, td.truncated.value');
+                            const val = valEl ? (valEl.getAttribute('title') || valEl.textContent).trim() : '';
+                            return label && val ? `${label}: ${val}` : '';
+                        })
+                        .filter(Boolean);
+
+                    saveData({ emailAge, deviceLocation, ip, declines });
+                };
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', run);
+                } else run();
+            } else if (path.includes('/workflow/ekata')) {
+                const run = () => {
+                    const btn = document.querySelector('input.simple-submit[value="Update Report"]');
+                    if (btn) btn.click();
+                    setTimeout(() => {
+                        const ipValid = findVal('Is Valid');
+                        const proxyRisk = findVal('Proxy Risk');
+                        const addressToName = findVal('Address to Name');
+                        const residentName = findVal('Resident Name');
+                        saveData({ ekata: { ipValid, proxyRisk, addressToName, residentName } });
+                        chrome.runtime.sendMessage({ action: 'refocusTab' });
+                    }, 1500);
+                };
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', run);
+                } else run();
+            }
+        } catch (e) {
+            console.error('[FENNEC Kount] Launcher error:', e);
+        }
+    });
+})();

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -104,6 +104,16 @@
         "styles/sidebar.css",
         "styles/sidebar_light.css"
       ]
+    },
+    {
+      "matches": [
+        "https://awc.kount.net/workflow/*"
+      ],
+      "all_frames": true,
+      "js": [
+        "core/utils.js",
+        "environments/kount/kount_launcher.js"
+      ]
     }
   ],
   "web_accessible_resources": [


### PR DESCRIPTION
## Summary
- parse Kount workflow and Ekata pages to store key info
- display new KOUNT summary box under DNA in DB/Gmail Fraud Review
- load summary whenever stored data changes
- document the new box and term in README and dictionary
- register the new content script in the manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ac0f534883268e71f2dafed54a3d