### PR TITLE
Adjust Fraud Review ordering

### DIFF
--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -94,28 +94,33 @@ In Review Mode the sidebar stays locked across all tabs until DNA runs on a diff
 MAIN:
    DB:
       Title: "ORDER SUMMARY"
-      1st box: ADYEN's DNA summary
+      1st box: COMPANY summary
+         - Same lines as the DB COMPANY box.
+      2nd box: ADYEN's DNA summary
          - Line 1: Card holder name.
          - Line 2: Payment method • last four digits • expiry • funding source.
          - Line 3: Billing address and issuing bank.
          - Line 4: CVV, AVS and DB match tags.
          - Line 5: Fraud scoring.
          - Line 6: Transaction table with totals.
-      2nd box: KOUNT summary
+      3rd box: KOUNT summary
          - Email age, device location, VIP declines and Ekata results.
-      3rd box: COMPANY summary (with restructured QUICK SUMMARY contained in the same box)
-         - Same lines as the DB COMPANY box.
-      4th box: CLIENT summary
-         - Line 1: Client name and ID link.
-         - Line 2: Role tags or NOT LISTED.
-         - Line 3: Email and phone.
-         - Line 4: Companies count and LTV.
-      5th box: BILLING summary
+      4th box: BILLING summary
          - Line 1: Cardholder name.
          - Line 2: Card type • last four digits • expiry.
          - Line 3: AVS result tag.
          - Line 4: Billing address.
-      6th box: Issue summary
+      5th box: CLIENT summary
+         - Line 1: Client name and ID link.
+         - Line 2: Role tags or NOT LISTED.
+         - Line 3: Email and phone.
+         - Line 4: Companies count and LTV.
+      6th box: AGENT summary
+         - Same lines as the DB AGENT box.
+      7th box: MEMBERS (LLC) or DIRECTORS (CORP, NPROFIT)
+      8th box: SHAREHOLDERS (CORP, NPROFIT)
+      9th box: Officers (CORP, NPROFIT)
+     10th box: Issue summary
          - Header with ACTIVE/RESOLVED tag and issue text.
    (Dev Mode) End: [🔄 REFRESH] button centered.
    GM:

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1116,7 +1116,7 @@
 
 
     function extractAndShowFormationData(isAmendment = false) {
-        const dbSections = [];
+        let dbSections = [];
         function addEmptySection(label, text = "NO INFO") {
             const section = `
             <div class="section-label">${label}</div>
@@ -1576,9 +1576,7 @@
                 `<span class="${vaClass}">VA: ${hasVA ? "Sí" : "No"}</span></div>`
             );
             const stateAttr = company.state ? ` data-state="${escapeHtml(company.state)}"` : '';
-            const compSection = reviewMode
-                ? `<div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}</div>`
-                : `<div class="section-label">COMPANY:</div><div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}</div>`;
+            const compSection = `<div class="section-label">COMPANY:</div><div class="white-box company-box"${stateAttr} style="margin-bottom:10px">${companyLines.join('').trim()}</div>`;
             if (companyLines.length) {
                 html += compSection;
                 dbSections.push(compSection);
@@ -1695,6 +1693,32 @@
             }
         }
 
+        if (reviewMode) {
+            const grab = label => {
+                const idx = dbSections.findIndex(s => s.includes(label));
+                return idx >= 0 ? dbSections.splice(idx, 1)[0] : '';
+            };
+            const ordered = [];
+            const company = grab('COMPANY:');
+            if (company) ordered.push(company);
+            const quick = grab('id="quick-summary"');
+            if (quick) ordered.push(quick);
+            const billing = grab('BILLING:');
+            if (billing) ordered.push(billing);
+            const client = grab('CLIENT:');
+            if (client) ordered.push(client);
+            const agent = grab('AGENT:');
+            if (agent) ordered.push(agent);
+            const members = grab('MEMBERS:') || grab('DIRECTORS:');
+            if (members) ordered.push(members);
+            const sh = grab('SHAREHOLDERS:');
+            if (sh) ordered.push(sh);
+            const off = grab('OFFICERS:');
+            if (off) ordered.push(off);
+            ordered.push(...dbSections);
+            dbSections = ordered;
+            html = dbSections.join('');
+        }
         if (!html) {
             html = `<div style="text-align:center; color:#aaa; margin-top:40px">No se encontró información relevante de la orden.</div>`;
         }

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -38,11 +38,11 @@
                 </div>
                 <div class="order-summary-header">ORDER SUMMARY</div>
                 <div class="copilot-body" id="copilot-body-content">
+                    <div id="db-summary-section"></div>
                     <div class="copilot-dna">
                         <div id="dna-summary" style="margin-top:16px"></div>
                         <div id="kount-summary" style="margin-top:10px"></div>
                     </div>
-                    <div id="db-summary-section"></div>
                     <div id="fraud-summary-section"></div>
                     <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                     <div id="review-mode-label" class="review-mode-label" style="margin-top:4px; text-align:center; font-size:11px;">REVIEW MODE</div>
@@ -471,6 +471,7 @@
 
         function loadDbSummary() {
             const container = document.getElementById('db-summary-section');
+            const fraud = document.getElementById('fraud-summary-section');
             if (!container) return;
             chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null, sidebarOrderInfo: null }, ({ sidebarDb, sidebarOrderId, sidebarOrderInfo }) => {
                 if (Array.isArray(sidebarDb) && sidebarDb.length) {
@@ -479,9 +480,11 @@
                     const qbox = container.querySelector('#quick-summary');
                     if (qbox) { qbox.classList.remove('quick-summary-collapsed'); qbox.style.maxHeight = 'none'; }
                     checkLastIssue(sidebarOrderId);
+                    if (fraud) fraud.innerHTML = '';
                 } else {
                     container.innerHTML = '';
                     fillIssueBox(null, null);
+                    if (fraud) insertFraudSummary();
                 }
             });
         }


### PR DESCRIPTION
## Summary
- reposition Fraud Review boxes so company summary appears first
- hide fraud summary when order details are visible
- show COMPANY: label in review mode
- document new Fraud Review order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866b6db5b148326b1a838cb95b76416