### PR TITLE
Fix trial floater background

### DIFF
--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -689,7 +689,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: var(--sb-box-bg);
+    background: var(--sb-box-bg, #2e2e2e);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -732,7 +732,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background-color: var(--sb-box-bg);
+    background-color: var(--sb-box-bg, #2e2e2e);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- ensure floating overlays use the default FENNEC background color when placed outside the sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866c65c42748326b2ba5e3b76d12f4b