### PR TITLE
Update fraud review floater styles

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -522,15 +522,19 @@
                 if (card['Expiry date']) adyenLines.push(`<div class="trial-line">${escapeHtml(card['Expiry date'])}</div>`);
                 if (proc['CVC/CVV']) {
                     const r = formatCvv(proc['CVC/CVV']);
-                    const tag = `<span class="copilot-tag ${colorFor(r.result)}">${escapeHtml(r.label)}</span>`;
-                    adyenLines.push(`<div class="trial-line">${tag}</div>`);
-                    pushFlag(tag);
+                    adyenLines.push(`<div class="trial-line">CVV: ${escapeHtml(proc['CVC/CVV'])}</div>`);
+                    if (r.result === 'green') {
+                        const tag = `<span class="copilot-tag ${colorFor(r.result)}">${escapeHtml(r.label)}</span>`;
+                        pushFlag(tag);
+                    }
                 }
                 if (proc['AVS']) {
                     const r = formatAvs(proc['AVS']);
-                    const tag = `<span class="copilot-tag ${colorFor(r.result)}">${escapeHtml(r.label)}</span>`;
-                    adyenLines.push(`<div class="trial-line">${tag}</div>`);
-                    pushFlag(tag);
+                    adyenLines.push(`<div class="trial-line">AVS: ${escapeHtml(proc['AVS'])}</div>`);
+                    if (r.result === 'green') {
+                        const tag = `<span class="copilot-tag ${colorFor(r.result)}">${escapeHtml(r.label)}</span>`;
+                        pushFlag(tag);
+                    }
                 }
                 const tx = dna.transactions || {};
                 const settled = parseAmount((tx['Settled'] || tx['Authorised / Settled'] || {}).amount);
@@ -559,7 +563,7 @@
 
             const html = `
                 <div class="trial-close">✕</div>
-                <h4 style="margin-top:0;text-align:center;font-weight:bold">FRAUD REVIEW</h4>
+                <h4 class="trial-title">FRAUD REVIEW</h4>
                 <div class="trial-columns">
                     <div class="trial-col"><b>DB</b>${dbLines.join('')}</div>
                     <div class="trial-col"><b>ADYEN</b>${adyenLines.join('')}</div>

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -739,10 +739,17 @@
     padding: 24px 32px;
     z-index: 1065;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
-    font-size: 26px;
+    font-size: var(--sb-font-size);
     text-align: left;
     width: 840px;
     max-width: 840px;
+}
+
+#fennec-trial-overlay .trial-title {
+    margin-top: 0;
+    text-align: center;
+    font-weight: bold;
+    color: #fff;
 }
 
 #fennec-trial-overlay .trial-close {
@@ -761,6 +768,10 @@
 #fennec-trial-overlay .trial-col {
     flex: 1;
     text-align: center;
+    background: #d3d3d3;
+    color: #000;
+    padding: 8px;
+    border-radius: 8px;
 }
 #fennec-trial-overlay .trial-summary {
     display: flex;

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -52,10 +52,16 @@
     width: 840px;
     max-width: 840px;
     padding: 24px 32px;
-    font-size: 26px;
+    font-size: var(--sb-font-size);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-close {
     color: #000;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-title {
+    margin-top: 0;
+    text-align: center;
+    font-weight: bold;
+    color: #fff;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-columns {
     display: flex;
@@ -65,6 +71,10 @@
 .fennec-light-mode #fennec-trial-overlay .trial-col {
     flex: 1;
     text-align: center;
+    background: #d3d3d3;
+    color: #000;
+    padding: 8px;
+    border-radius: 8px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-summary {
     display: flex;


### PR DESCRIPTION
## Summary
- tweak fraud review floater title style and font size
- show raw CVV and AVS strings in Adyen column and report matches only in green flags
- style floater columns with light gray boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866cc6501488326bf7f55e7dd606edc