### PR TITLE
Prevent XRAY reruns after trial floater

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -13,7 +13,16 @@
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
     let devMode = false;
-    const fraudXray = new URLSearchParams(location.search).get('fraud_xray') === '1';
+    let fraudXray = new URLSearchParams(location.search).get('fraud_xray') === '1';
+    const xrayDone = localStorage.getItem('fraudXrayCompleted') === '1';
+    if (fraudXray && xrayDone) {
+        const params = new URLSearchParams(location.search);
+        params.delete('fraud_xray');
+        const newUrl = location.pathname + (params.toString() ? '?' + params.toString() : '');
+        history.replaceState(null, '', newUrl);
+        localStorage.removeItem('fraudXrayCompleted');
+        fraudXray = false;
+    }
 
     // Some DB pages do not show the correct LTV value until the order is
     // refreshed. Refresh once the first time the order loads in a new tab.
@@ -529,7 +538,7 @@
                         }
                         loadDnaSummary();
                         loadKountSummary();
-                        setTimeout(runFraudXray, 500);
+                        if (fraudXray) setTimeout(runFraudXray, 500);
                     });
                     const qsToggle = sidebar.querySelector('#qs-toggle');
                     initQuickSummary = () => {

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -432,6 +432,7 @@
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
             if (!flag) return;
             sessionStorage.removeItem('fennecShowTrialFloater');
+            localStorage.setItem('fraudXrayCompleted', '1');
             chrome.storage.local.get({ adyenDnaInfo: null, kountInfo: null, sidebarOrderInfo: null }, data => {
                 const html = buildTrialHtml(data.adyenDnaInfo, data.kountInfo, data.sidebarOrderInfo);
                 if (!html) return;


### PR DESCRIPTION
## Summary
- stop DB fraud XRAY from repeating once the trial floater has shown
- record completion in `localStorage` and skip rerun on refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866cd848c008326b0594c93a4e20cfb