### PR TITLE
Add trial floater improvements

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1771,7 +1771,8 @@
             formationDate: company ? company.formationDate : null,
             registeredAgent: hasAgentInfo ? { name: agent.name, address: agent.address } : null,
             members: directors,
-            billing
+            billing,
+            clientLtv: client.ltv
         };
         chrome.storage.local.set({
             sidebarDb: dbSections,

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -745,11 +745,11 @@
     max-width: 840px;
 }
 
-#fennec-trial-overlay .trial-title {
-    margin-top: 0;
+#fennec-trial-title {
     text-align: center;
     font-weight: bold;
     color: #fff;
+    margin-bottom: 4px;
 }
 
 #fennec-trial-overlay .trial-close {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -57,11 +57,11 @@
 .fennec-light-mode #fennec-trial-overlay .trial-close {
     color: #000;
 }
-.fennec-light-mode #fennec-trial-overlay .trial-title {
-    margin-top: 0;
+.fennec-light-mode #fennec-trial-title {
     text-align: center;
     font-weight: bold;
     color: #fff;
+    margin-bottom: 4px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-columns {
     display: flex;


### PR DESCRIPTION
## Summary
- save client LTV in sidebar info
- add clear tabs button in Fraud Review sidebar header
- display LTV value in trial floater
- show trial floater title above overlay
- style trial floater title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866cf75f97c8326b076d675ca7f3021