### PR TITLE
Fix XRAY completion state per order

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -14,7 +14,12 @@
     let reviewMode = false;
     let devMode = false;
     let fraudXray = new URLSearchParams(location.search).get('fraud_xray') === '1';
-    const xrayDone = localStorage.getItem('fraudXrayCompleted') === '1';
+    const currentId = (location.pathname.match(/(?:detail|storage\/incfile)\/(\d+)/) || [])[1];
+    const xrayDoneId = localStorage.getItem('fraudXrayCompleted');
+    const xrayDone = xrayDoneId && currentId && xrayDoneId === currentId;
+    if (xrayDoneId && currentId && xrayDoneId !== currentId) {
+        localStorage.removeItem('fraudXrayCompleted');
+    }
     if (fraudXray && xrayDone) {
         const params = new URLSearchParams(location.search);
         params.delete('fraud_xray');

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -448,8 +448,12 @@
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
             if (!flag) return;
             sessionStorage.removeItem('fennecShowTrialFloater');
-            localStorage.setItem('fraudXrayCompleted', '1');
             chrome.storage.local.get({ adyenDnaInfo: null, kountInfo: null, sidebarOrderInfo: null }, data => {
+                if (data.sidebarOrderInfo && data.sidebarOrderInfo.orderId) {
+                    localStorage.setItem('fraudXrayCompleted', String(data.sidebarOrderInfo.orderId));
+                } else {
+                    localStorage.setItem('fraudXrayCompleted', '1');
+                }
                 const html = buildTrialHtml(data.adyenDnaInfo, data.kountInfo, data.sidebarOrderInfo);
                 if (!html) return;
                 let overlay = document.getElementById('fennec-trial-overlay');


### PR DESCRIPTION
## Summary
- track the completed XRAY order in `localStorage`
- reset old XRAY data when a new order loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d46b864083268f9bf2ea8f1eeb7d