### PR TITLE
Add subscription detection feature

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -389,6 +389,55 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
 
+    if (message.action === "detectSubscriptions" && message.email && sender.tab) {
+        const originTab = sender.tab.id;
+        let base = "https://db.incfile.com";
+        try {
+            const url = new URL(sender.tab.url);
+            if (url.hostname.endsWith("incfile.com")) base = url.origin;
+        } catch (err) {
+            console.warn("[Copilot] Invalid sender URL", sender.tab.url);
+        }
+        const url = `${base}/db-tools/scan-email-address?fennec_email=${encodeURIComponent(message.email)}`;
+        chrome.tabs.create({ url, active: false, windowId: sender.tab.windowId }, tab => {
+            if (chrome.runtime.lastError || !tab) { sendResponse(null); return; }
+            const resultListener = (msg, snd) => {
+                if (msg.action === 'dbEmailSearchResults' && snd.tab && snd.tab.id === tab.id) {
+                    chrome.runtime.onMessage.removeListener(resultListener);
+                    const orders = msg.orders || [];
+                    const formationIds = orders.filter(o => /formation/i.test(o.type)).map(o => o.orderId).filter(Boolean);
+                    let idx = 0;
+                    const activeSubs = [];
+                    const checkNext = () => {
+                        if (idx >= formationIds.length) {
+                            chrome.tabs.remove(tab.id);
+                            chrome.tabs.update(originTab, { active: true });
+                            sendResponse({ orderCount: orders.length, activeSubs, ltv: message.ltv });
+                            return;
+                        }
+                        const id = formationIds[idx++];
+                        const detailUrl = `${base}/incfile/order/detail/${id}?fennec_sub_check=1`;
+                        chrome.tabs.create({ url: detailUrl, active: false, windowId: sender.tab.windowId }, oTab => {
+                            const listener = (tid, info) => {
+                                if (tid === oTab.id && info.status === 'complete') {
+                                    chrome.tabs.onUpdated.removeListener(listener);
+                                    chrome.tabs.sendMessage(oTab.id, { action: 'getActiveSubs' }, resp => {
+                                        if (resp && Array.isArray(resp.subs) && resp.subs.length) activeSubs.push(id);
+                                        chrome.tabs.remove(oTab.id, checkNext);
+                                    });
+                                }
+                            };
+                            chrome.tabs.onUpdated.addListener(listener);
+                        });
+                    };
+                    checkNext();
+                }
+            };
+            chrome.runtime.onMessage.addListener(resultListener);
+        });
+        return true;
+    }
+
     if (message.action === "sosSearch" && message.url && message.query) {
         const openSearchTab = () => {
             chrome.tabs.create({ url: message.url, active: true }, (tab) => {

--- a/FENNEC/environments/db/db_email_search.js
+++ b/FENNEC/environments/db/db_email_search.js
@@ -1,0 +1,33 @@
+(function() {
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) return;
+        const params = new URLSearchParams(location.search);
+        const email = params.get('fennec_email');
+        if (!email) return;
+        function run() {
+            const input = document.querySelector('#search_field');
+            if (input) {
+                input.value = email;
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            const btn = document.querySelector('button[type="submit"],input[type="submit"]');
+            if (btn) btn.click();
+            const gather = () => {
+                const rows = document.querySelectorAll('.search_result tbody tr');
+                if (!rows.length) { setTimeout(gather, 500); return; }
+                const orders = Array.from(rows).map(r => {
+                    const link = r.querySelector('a[href*="/order/detail/"]');
+                    const id = link ? link.textContent.replace(/\D+/g, '') : '';
+                    const typeCell = r.querySelector('td:nth-child(4)');
+                    const type = typeCell ? typeCell.textContent.trim() : '';
+                    return { orderId: id, type };
+                });
+                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
+            };
+            gather();
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', run);
+        } else run();
+    });
+})();

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -474,6 +474,37 @@
                 });
                 document.body.appendChild(title);
                 document.body.appendChild(overlay);
+                const subBtn = overlay.querySelector('#sub-detection-btn');
+                if (subBtn) {
+                    subBtn.addEventListener('click', () => {
+                        subBtn.disabled = true;
+                        chrome.runtime.sendMessage({
+                            action: 'detectSubscriptions',
+                            email: (data.sidebarOrderInfo && data.sidebarOrderInfo.clientEmail) || '',
+                            ltv: (data.sidebarOrderInfo && data.sidebarOrderInfo.clientLtv) || ''
+                        }, resp => {
+                            subBtn.disabled = false;
+                            if (!resp) return;
+                            const dbCol = overlay.querySelector('.trial-col');
+                            if (!dbCol) return;
+                            const line1 = document.createElement('div');
+                            line1.className = 'trial-line';
+                            line1.textContent = `Orders: ${resp.orderCount}`;
+                            dbCol.appendChild(line1);
+                            if (resp.ltv) {
+                                const ratio = resp.orderCount && parseFloat(resp.ltv) ? (resp.orderCount / parseFloat(resp.ltv)).toFixed(2) : 'N/A';
+                                const line2 = document.createElement('div');
+                                line2.className = 'trial-line';
+                                line2.textContent = `Orders/LTV: ${ratio}`;
+                                dbCol.appendChild(line2);
+                            }
+                            const line3 = document.createElement('div');
+                            line3.className = 'trial-line';
+                            line3.textContent = 'Active Subs: ' + (resp.activeSubs.length ? resp.activeSubs.join(', ') : 'None');
+                            dbCol.appendChild(line3);
+                        });
+                    });
+                }
             });
         }
 
@@ -541,7 +572,7 @@
                 if (!ltv) ltv = getClientLtv();
                 if (ltv) dbLines.push(`<div class="trial-line">LTV: ${escapeHtml(ltv)}</div>`);
                 else dbLines.push(`<div class="trial-line">LTV: N/A</div>`);
-                const btn = `<button id="sub-detection-btn">SUB DETECTION</button>`;
+                const btn = `<button id="sub-detection-btn" class="sub-detect-btn">SUB DETECTION</button>`;
                 dbLines.push(`<div class="trial-line">${btn}</div>`);
             }
 

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -71,6 +71,16 @@
     },
     {
       "matches": [
+        "https://db.incfile.com/db-tools/scan-email-address*"
+      ],
+      "all_frames": true,
+      "js": [
+        "core/utils.js",
+        "environments/db/db_email_search.js"
+      ]
+    },
+    {
+      "matches": [
         "https://tools.usps.com/zip-code-lookup.htm*"
       ],
       "js": [

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -876,3 +876,13 @@
     background: #1e1e1e;
     color: #fff;
 }
+
+.sub-detect-btn {
+    border-radius: 20px;
+    padding: 4px 10px;
+    transition: transform 0.2s;
+}
+.sub-detect-btn:hover {
+    transform: scale(1.1);
+}
+


### PR DESCRIPTION
## Summary
- implement SUB DETECTION logic in fraud review floater
- expose client email in DB sidebar data
- add helper to parse active subscriptions
- handle new `detectSubscriptions` request in background
- auto search by email with new script
- register content script and button styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d8113eb88326b043fd1b360fa8f9