### PR TITLE
Restrict DB auto refresh

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 - Quick Summary no longer auto-expands on Annual Report orders and the
   Family Tree panel loads automatically.
+- DB order pages now refresh automatically only during FRAUD REVIEW or
+  REVIEW XRAY flows to ensure the LTV value loads correctly.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -31,11 +31,13 @@
     }
 
     // Some DB pages do not show the correct LTV value until the order is
-    // refreshed. Refresh once the first time the order loads in a new tab.
+    // refreshed. This should only happen during FRAUD REVIEW or REVIEW XRAY
+    // flows so the sidebar retrieves accurate data.
     (function refreshForLtv() {
         const m = location.pathname.match(/(?:detail|storage\/incfile)\/(\d+)/);
         const orderId = m ? m[1] : null;
         if (!orderId) return;
+        if (!fraudXray && !subCheck) return;
         const key = 'fennecLtvRefreshed_' + orderId;
         if (sessionStorage.getItem(key)) return;
         sessionStorage.setItem(key, '1');


### PR DESCRIPTION
## Summary
- only refresh DB order pages during FRAUD REVIEW or REVIEW XRAY flows
- note refresh behavior change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866dbbf24c88326b663616eb19907c1