### PR TITLE
Use DB order search for subscription lookup

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -398,14 +398,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } catch (err) {
             console.warn("[Copilot] Invalid sender URL", sender.tab.url);
         }
-        const url = `${base}/db-tools/scan-email-address?fennec_email=${encodeURIComponent(message.email)}`;
+        const url = `${base}/order-tracker/orders/order-search?fennec_email=${encodeURIComponent(message.email)}`;
         chrome.tabs.create({ url, active: false, windowId: sender.tab.windowId }, tab => {
             if (chrome.runtime.lastError || !tab) { sendResponse(null); return; }
             const resultListener = (msg, snd) => {
                 if (msg.action === 'dbEmailSearchResults' && snd.tab && snd.tab.id === tab.id) {
                     chrome.runtime.onMessage.removeListener(resultListener);
                     const orders = msg.orders || [];
-                    const formationIds = orders.filter(o => /formation/i.test(o.type)).map(o => o.orderId).filter(Boolean);
+                    const formationIds = orders
+                        .filter(o => /formation|silver|gold|platinum/i.test(o.type))
+                        .map(o => o.orderId)
+                        .filter(Boolean);
                     let idx = 0;
                     const activeSubs = [];
                     const checkNext = () => {

--- a/FENNEC/environments/db/db_order_search.js
+++ b/FENNEC/environments/db/db_order_search.js
@@ -1,0 +1,35 @@
+(function() {
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) return;
+        const params = new URLSearchParams(location.search);
+        const email = params.get('fennec_email');
+        if (!email) return;
+        function run() {
+            const input = document.querySelector('#search_field');
+            if (input) {
+                input.value = email;
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            const btn = document.getElementById('mainSearching') || document.querySelector('#mainSearching');
+            if (btn) btn.click();
+            const gather = () => {
+                const rows = document.querySelectorAll('.search_result tbody tr');
+                if (!rows.length) { setTimeout(gather, 500); return; }
+                const orders = Array.from(rows).map(r => {
+                    const link = r.querySelector('a[href*="/order/detail/"]');
+                    const id = link ? link.textContent.replace(/\D+/g, '') : '';
+                    const cells = r.querySelectorAll('td');
+                    let type = '';
+                    if (cells.length >= 6) type = cells[5].textContent.trim();
+                    else if (cells.length >= 4) type = cells[3].textContent.trim();
+                    return { orderId: id, type };
+                });
+                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
+            };
+            gather();
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', run);
+        } else run();
+    });
+})();

--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -81,6 +81,16 @@
     },
     {
       "matches": [
+        "https://db.incfile.com/order-tracker/orders/order-search*"
+      ],
+      "all_frames": true,
+      "js": [
+        "core/utils.js",
+        "environments/db/db_order_search.js"
+      ]
+    },
+    {
+      "matches": [
         "https://tools.usps.com/zip-code-lookup.htm*"
       ],
       "js": [


### PR DESCRIPTION
## Summary
- add script for order search results
- load script on order search pages
- search for subs via order search instead of email scan
- treat Silver/Gold/Platinum orders as formation types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e41aaae88326a9a1d231ee68033d