### PR TITLE
Fix duplicate parent order tabs

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -40,6 +40,7 @@
   Family Tree panel loads automatically.
 - DB order pages now refresh automatically only during FRAUD REVIEW or
   REVIEW XRAY flows to ensure the LTV value loads correctly.
+- Fixed duplicate parent order tabs in the Family Tree flow by creating only one background tab.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -283,11 +283,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 const ensureLoaded = () => {
                     if (!tab || tab.status !== "complete") {
                         if (attempts > 0) {
-                            if (!tab) {
-                            chrome.tabs.create({ url, active: false, windowId: sender.tab ? sender.tab.windowId : undefined }, t => {
-                                tab = t;
-                                createdTabId = t.id;
-                            });
+                            if (!tab && !createdTabId) {
+                                chrome.tabs.create({ url, active: false, windowId: sender.tab ? sender.tab.windowId : undefined }, t => {
+                                    tab = t;
+                                    createdTabId = t.id;
+                                });
                             }
                             setTimeout(() => {
                                 attempts--;


### PR DESCRIPTION
## Summary
- prevent opening multiple tabs when fetching Family Tree orders
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866fbee8b28832688786c02b9517499