### PR TITLE
Fix family tree auto open

### DIFF
--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -123,7 +123,7 @@ function attachCommonListeners(rootEl) {
                     return;
                 }
             }
-            if (container.style.maxHeight && container.style.maxHeight !== '0px') {
+            if (container.style.maxHeight && parseInt(container.style.maxHeight) > 0) {
                 container.style.maxHeight = '0';
                 container.classList.add('ft-collapsed');
                 return;

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -10,6 +10,7 @@
     let annualReportMode = false;
     let reinstatementMode = false;
     let miscMode = false;
+    let autoFamilyTreeDone = false;
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
     let devMode = false;
@@ -75,8 +76,10 @@
     }
 
     function autoOpenFamilyTree() {
+        if (autoFamilyTreeDone) return;
         const ftIcon = document.getElementById('family-tree-icon');
         if (ftIcon && ftIcon.style.display !== 'none') {
+            autoFamilyTreeDone = true;
             ftIcon.click();
         }
     }


### PR DESCRIPTION
## Summary
- avoid duplicate tabs when auto-opening family tree
- improve open/close logic for family tree box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be152a70c8326917b7c458e577071