### PR TITLE
Fix double tabs on Family Tree auto-open

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -41,6 +41,7 @@
 - DB order pages now refresh automatically only during FRAUD REVIEW or
   REVIEW XRAY flows to ensure the LTV value loads correctly.
 - Fixed duplicate parent order tabs in the Family Tree flow by creating only one background tab.
+- Fixed Family Tree auto-open on miscellaneous orders so the parent order opens only once.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -108,7 +108,8 @@ function attachCommonListeners(rootEl) {
         });
     });
     const ftIcon = document.getElementById('family-tree-icon');
-    if (ftIcon) {
+    if (ftIcon && !ftIcon.dataset.listenerAttached) {
+        ftIcon.dataset.listenerAttached = 'true';
         ftIcon.addEventListener('click', () => {
             console.log('[Copilot] Family Tree icon clicked');
             let container = document.getElementById('family-tree-orders');


### PR DESCRIPTION
## Summary
- prevent attaching duplicate Family Tree listeners
- note fix for misc orders in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be37810908326a6307d7bda5c5d17