### PR TITLE
Fix family tree overwriting Gmail data

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -42,6 +42,8 @@
   REVIEW XRAY flows to ensure the LTV value loads correctly.
 - Fixed duplicate parent order tabs in the Family Tree flow by creating only one background tab.
 - Fixed Family Tree auto-open on miscellaneous orders so the parent order opens only once.
+- Fetching the Family Tree for miscellaneous orders no longer overwrites Gmail
+  sidebar data with the parent order information.
 
 ## v0.3 - 2025-06-24
 

--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -271,7 +271,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 console.warn("[Copilot] Invalid sender URL", sender.tab.url);
             }
         }
-        const url = `${base}/incfile/order/detail/${orderId}`;
+        const url = `${base}/incfile/order/detail/${orderId}?fennec_no_store=1`;
         const query = { url: `${url}*` };
         let attempts = 15;
         let delay = 1000;

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -11,6 +11,7 @@
     let reinstatementMode = false;
     let miscMode = false;
     let autoFamilyTreeDone = false;
+    let noStore = new URLSearchParams(location.search).get('fennec_no_store') === '1';
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
     let devMode = false;
@@ -432,8 +433,8 @@
     }
 
     chrome.storage.local.get({ extensionEnabled: true, lightMode: false, fennecReviewMode: false, fennecDevMode: false }, ({ extensionEnabled, lightMode, fennecReviewMode, fennecDevMode }) => {
-        if (!extensionEnabled) {
-            console.log('[FENNEC] Extension disabled, skipping DB launcher.');
+        if (!extensionEnabled || noStore) {
+            console.log('[FENNEC] Extension disabled or no-store mode, skipping DB launcher.');
             return;
         }
         if (lightMode) {


### PR DESCRIPTION
## Summary
- avoid storing sidebar data when loading a parent order in the background
- load parent orders with `fennec_no_store=1` so stored data isn't replaced
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be90afaf88326865135e4f31c49c5