### PR TITLE
Fix Gmail sidebar comment input and context

### DIFF
--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1165,10 +1165,9 @@
                 if (cText) cText.remove();
                 let input = document.getElementById('issue-comment-input');
                 if (!input) {
-                    input = document.createElement('input');
+                    input = document.createElement('textarea');
                     input.id = 'issue-comment-input';
                     input.className = 'quick-resolve-comment';
-                    input.type = 'text';
                     input.placeholder = 'Comment...';
                     issueBox.appendChild(input);
                 } else {
@@ -1225,10 +1224,9 @@
                 if (cText) cText.remove();
                 let input = document.getElementById('issue-comment-input');
                 if (!input) {
-                    input = document.createElement('input');
+                    input = document.createElement('textarea');
                     input.id = 'issue-comment-input';
                     input.className = 'quick-resolve-comment';
-                    input.type = 'text';
                     input.placeholder = 'Comment...';
                     issueBox.appendChild(input);
                 } else {
@@ -1261,6 +1259,10 @@
                     chrome.storage.local.set({ sidebarFreezeId: null, adyenDnaInfo: null });
                 }
             });
+            if (!ctx) {
+                showInitialStatus();
+                return;
+            }
             fillOrderSummaryBox(ctx);
             loadDbSummary(ctx && ctx.orderNumber);
             if (ctx && ctx.orderNumber) checkLastIssue(ctx.orderNumber);
@@ -1359,7 +1361,7 @@
                     <div class="issue-summary-box" id="issue-summary-box" style="margin-top:10px;">
                         <strong>ISSUE <span id="issue-status-label" class="issue-status-label"></span></strong><br>
                         <div id="issue-summary-content" style="color:#ccc; font-size:13px; white-space:pre-line;">No issue data yet.</div>
-                        <input id="issue-comment-input" class="quick-resolve-comment" type="text" placeholder="Comment..." />
+                        <textarea id="issue-comment-input" class="quick-resolve-comment" placeholder="Comment..."></textarea>
                         <button id="issue-resolve-btn" class="copilot-button" style="margin-top:4px;">COMMENT &amp; RESOLVE</button>
                     </div>
                     ${devMode ? `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>` : ``}

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -194,6 +194,8 @@
     border: 1px solid #888;
     color: #000;
     box-sizing: border-box;
+    min-height: 40px;
+    resize: vertical;
 }
 
 .quick-resolve-comment-text {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -207,6 +207,11 @@
     background: #fff;
     color: #000;
 }
+.fennec-light-mode .quick-resolve-comment {
+    border: 1px solid #777;
+    background: #fff;
+    color: #000;
+}
 
 /* Use inverted Fennec icon in light mode */
 .fennec-light-mode .copilot-icon,


### PR DESCRIPTION
## Summary
- allow multiline comment input in Gmail sidebar
- show the Gmail sidebar's initial view when outside an email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bee35142883268f5811b9b785c040