### PR TITLE
Fix duplicate billing search tab in Fraud Review

### DIFF
--- a/FENNEC/environments/kount/kount_launcher.js
+++ b/FENNEC/environments/kount/kount_launcher.js
@@ -77,7 +77,7 @@
                         chrome.storage.local.get({ fennecFraudAdyen: null }, ({ fennecFraudAdyen }) => {
                             if (fennecFraudAdyen) {
                                 chrome.storage.local.remove('fennecFraudAdyen');
-                                chrome.runtime.sendMessage({ action: 'openTab', url: fennecFraudAdyen, active: true });
+                                chrome.runtime.sendMessage({ action: 'openOrReuseTab', url: fennecFraudAdyen, active: true });
                             } else {
                                 chrome.runtime.sendMessage({ action: 'refocusTab' });
                             }


### PR DESCRIPTION
## Summary
- avoid opening additional billing search tab during Fraud Review XRAY by reusing the existing Adyen tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bf8f6dba0832690a4bd70eeb769e1