### PR TITLE
Add company info and RA/VA flags in fraud review

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1795,6 +1795,10 @@
             registeredAgent: hasAgentInfo ? { name: agent.name, address: agent.address } : null,
             members: directors,
             billing,
+            hasVA,
+            hasRA,
+            raExpired,
+            orderCost: getOrderCost(),
             clientLtv: client.ltv,
             clientEmail: client.email
         };
@@ -2455,6 +2459,15 @@
         if (!li) return false;
         const span = li.querySelector('span.pull-right');
         return span && /expedited/i.test(getText(span));
+    }
+
+    function getOrderCost() {
+        const li = Array.from(document.querySelectorAll('li')).find(li => {
+            return /charge total/i.test(getText(li));
+        });
+        if (!li) return '';
+        const span = li.querySelector('.pull-right.total');
+        return span ? getText(span) : '';
     }
 
     function getParentOrderId() {

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -767,6 +767,10 @@
     gap: 12px;
     margin-bottom: 8px;
 }
+#fennec-trial-overlay .trial-order {
+    text-align: center;
+    margin-bottom: 8px;
+}
 #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
     text-align: center;
@@ -795,6 +799,15 @@
 
 #fennec-trial-overlay .trial-line {
     margin: 4px 0;
+}
+#fennec-trial-overlay .name-match {
+    margin-left: 4px;
+}
+#fennec-trial-overlay .name-match.check {
+    color: #0a0;
+}
+#fennec-trial-overlay .name-match.cross {
+    color: #000;
 }
 
 #fennec-kb-backdrop {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -68,6 +68,10 @@
     gap: 12px;
     margin-bottom: 8px;
 }
+.fennec-light-mode #fennec-trial-overlay .trial-order {
+    text-align: center;
+    margin-bottom: 8px;
+}
 .fennec-light-mode #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
     text-align: center;
@@ -210,6 +214,16 @@
 .fennec-light-mode .quick-resolve-comment {
     border: 1px solid #777;
     background: #fff;
+    color: #000;
+}
+
+.fennec-light-mode #fennec-trial-overlay .name-match {
+    margin-left: 4px;
+}
+.fennec-light-mode #fennec-trial-overlay .name-match.check {
+    color: #0a0;
+}
+.fennec-light-mode #fennec-trial-overlay .name-match.cross {
     color: #000;
 }
 


### PR DESCRIPTION
## Summary
- extend sidebar order info with RA/VA status and order cost
- parse order cost from DB order page
- show new company info box and name-matching icon on fraud review floater
- display RA/VA status lines in DB column and flag when cardholder matches members or RA
- style new elements for both themes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c1f8673c88326a1cdb843ed7f63e3