### PR TITLE
Fix review mode enabling

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
+- Activating Review Mode from the popup now reloads DB pages so the sidebar appears automatically.
 - Fixed the Mistral chat box disappearing after loading the order summary.
 - The Mistral Box now sends prompts to a local Ollama server at
   `http://127.0.0.1:11434/api/generate`.


### PR DESCRIPTION
## Summary
- reload DB tabs when switching review mode from the popup so the sidebar shows up
- document the fix in the changelog

## Testing
- `npm test --prefix FENNEC`

------
https://chatgpt.com/codex/tasks/task_e_686c28ebbd888326ae35c66aee56fbc9