### PR TITLE
Fix review mode toggle for fraud tracker

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
 - Activating Review Mode from the popup now reloads DB pages so the sidebar appears automatically.
+- The Fraud tracker page also reloads so Review Mode shows the sidebar.
 - Fixed the Mistral chat box disappearing after loading the order summary.
 - The Mistral Box now sends prompts to a local Ollama server at
   `http://127.0.0.1:11434/api/generate`.

--- a/FENNEC/popup.js
+++ b/FENNEC/popup.js
@@ -20,6 +20,7 @@ function saveState() {
                 "https://mail.google.com/*",
                 "https://*.incfile.com/incfile/order/detail/*",
                 "https://*.incfile.com/storage/incfile/*",
+                "https://db.incfile.com/order-tracker/orders/fraud*",
                 "https://tools.usps.com/*"
             ];
 


### PR DESCRIPTION
## Summary
- refresh the Fraud tracker page when toggling Review Mode in the popup
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c3b2c88d08326aa202a2463dd7084