### PR TITLE
Fix redundant host permission in manifest

### DIFF
--- a/FENNEC/manifest.json
+++ b/FENNEC/manifest.json
@@ -21,9 +21,6 @@
         "http://127.0.0.1:11434/*",
         "https://*/*"
     ],
-  "optional_host_permissions": [
-    "https://*/*"
-  ],
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
## Summary
- remove the `optional_host_permissions` section from `manifest.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c3e4f52908326a8cd0c10f5986f81