### PR TITLE
Fix DNA summary reference error

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2002,6 +2002,9 @@
         });
     }
 
+    // Expose for other scripts that may call it
+    window.loadDnaSummary = loadDnaSummary;
+
     function buildKountHtml(info) {
         if (!info) return null;
         const parts = [];
@@ -2034,6 +2037,9 @@
             attachCommonListeners(container);
         });
     }
+
+    // Expose for other scripts
+    window.loadKountSummary = loadKountSummary;
 
     function formatIssueText(text) {
         if (!text) return '';

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -423,26 +423,31 @@
             return `<div class="section-label">KOUNT</div><div class="white-box" style="margin-bottom:10px">${parts.join('')}</div>`;
         }
 
-        function loadDnaSummary() {
-            const container = document.getElementById('dna-summary');
-            if (!container) return;
-            chrome.storage.local.get({ adyenDnaInfo: null, sidebarOrderInfo: null }, ({ adyenDnaInfo, sidebarOrderInfo }) => {
-                if (adyenDnaInfo) adyenDnaInfo.dbBilling = sidebarOrderInfo ? sidebarOrderInfo.billing : null;
-                const html = buildDnaHtml(adyenDnaInfo);
-                container.innerHTML = html || '';
-                attachCommonListeners(container);
-            });
-        }
+       function loadDnaSummary() {
+           const container = document.getElementById('dna-summary');
+           if (!container) return;
+           chrome.storage.local.get({ adyenDnaInfo: null, sidebarOrderInfo: null }, ({ adyenDnaInfo, sidebarOrderInfo }) => {
+               if (adyenDnaInfo) adyenDnaInfo.dbBilling = sidebarOrderInfo ? sidebarOrderInfo.billing : null;
+               const html = buildDnaHtml(adyenDnaInfo);
+               container.innerHTML = html || '';
+               attachCommonListeners(container);
+           });
+       }
 
-        function loadKountSummary() {
-            const container = document.getElementById('kount-summary');
-            if (!container) return;
-            chrome.storage.local.get({ kountInfo: null }, ({ kountInfo }) => {
-                const html = buildKountHtml(kountInfo);
-                container.innerHTML = html || '';
-                attachCommonListeners(container);
-            });
-        }
+        // Make callable from page scripts
+        window.loadDnaSummary = loadDnaSummary;
+
+       function loadKountSummary() {
+           const container = document.getElementById('kount-summary');
+           if (!container) return;
+           chrome.storage.local.get({ kountInfo: null }, ({ kountInfo }) => {
+               const html = buildKountHtml(kountInfo);
+               container.innerHTML = html || '';
+               attachCommonListeners(container);
+           });
+       }
+
+        window.loadKountSummary = loadKountSummary;
 
         function showTrialFloater(retries = 5) {
             const flag = sessionStorage.getItem('fennecShowTrialFloater');


### PR DESCRIPTION
## Summary
- expose `loadDnaSummary` and `loadKountSummary` on the window object
- make these helpers globally available in fraud tracker script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c42e8f4648326acc6af86f87a9c75