### PR TITLE
Fix XRAY trial overlay timing

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -449,7 +449,9 @@
 
         window.loadKountSummary = loadKountSummary;
 
-        function showTrialFloater(retries = 5) {
+        // Displays the floating TRIAL SUMMARY once XRAY data is available.
+        // Allow a few extra retries in case Kount or Adyen info is delayed.
+        function showTrialFloater(retries = 10) {
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
             if (!flag || retries <= 0) return;
             const summary = document.getElementById('fraud-summary-box');
@@ -859,6 +861,9 @@
             }
             if (area === 'local' && changes.kountInfo) {
                 loadKountSummary();
+            }
+            if (area === 'local' && (changes.adyenDnaInfo || changes.kountInfo)) {
+                showTrialFloater();
             }
         });
         window.addEventListener('focus', () => {


### PR DESCRIPTION
## Summary
- show trial overlay after XRAY when Kount or Adyen data arrives
- allow more retries waiting for XRAY data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c460ccfa88326b6ecc9f5ad6669b1