### PR TITLE
Fix Adyen info missing on trial floater

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The payment step logs the dropdown selector and value before clicking **Continue** so you can confirm **Client Account** is selected.
 - Fraud Review shows a floating **TRIAL SUMMARY** with CVV, AVS, DB match and Kount checks after returning from XRAY.
 - TRIAL SUMMARY overlay now waits for XRAY data and retries briefly if the information isn't ready.
+- TRIAL SUMMARY waits for Adyen data so the ADYEN column appears after XRAY.
 - Family Tree detects duplicate orders in review, processing or hold and adds a ❌ icon to cancel and refund them.
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -457,6 +457,10 @@
             const summary = document.getElementById('fraud-summary-box');
             if (summary) summary.remove();
             chrome.storage.local.get({ adyenDnaInfo: null, kountInfo: null, sidebarOrderInfo: null }, data => {
+                if (!data.adyenDnaInfo) {
+                    setTimeout(() => showTrialFloater(retries - 1), 1000);
+                    return;
+                }
                 const html = buildTrialHtml(data.adyenDnaInfo, data.kountInfo, data.sidebarOrderInfo);
                 if (!html) {
                     setTimeout(() => showTrialFloater(retries - 1), 1000);


### PR DESCRIPTION
## Summary
- wait for Adyen data before rendering the trial summary overlay
- document fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c48a8b1808326a16ee7d8772aabac