### PR TITLE
Add fraud review action buttons

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -518,6 +518,41 @@
                         });
                     });
                 }
+                const orderId = data.sidebarOrderInfo && data.sidebarOrderInfo.orderId;
+                function clickDbAction(selector) {
+                    if (!orderId) return;
+                    const row = document.querySelector(`tr[data-order-id="${orderId}"]`);
+                    if (!row) return;
+                    const btn = row.querySelector(selector);
+                    if (btn) btn.click();
+                }
+                const crBtn = overlay.querySelector('#trial-btn-cr');
+                if (crBtn) crBtn.addEventListener('click', () => clickDbAction('.cancel-and-refund-potential-fraud'));
+                const idBtn = overlay.querySelector('#trial-btn-id');
+                if (idBtn) idBtn.addEventListener('click', () => clickDbAction('.confirm-fraud-potential-fraud'));
+                const relBtn = overlay.querySelector('#trial-btn-release');
+                if (relBtn) relBtn.addEventListener('click', () => clickDbAction('.remove-potential-fraud'));
+
+                const crossCount = overlay.querySelectorAll('.db-adyen-cross').length;
+                const bigSpot = overlay.querySelector('#trial-big-button');
+                if (bigSpot) {
+                    let srcBtn = relBtn;
+                    let handler = () => clickDbAction('.remove-potential-fraud');
+                    if (crossCount > 4) {
+                        srcBtn = crBtn;
+                        handler = () => clickDbAction('.cancel-and-refund-potential-fraud');
+                    } else if (crossCount > 0) {
+                        srcBtn = idBtn;
+                        handler = () => clickDbAction('.confirm-fraud-potential-fraud');
+                    }
+                    if (srcBtn) {
+                        const bigBtn = srcBtn.cloneNode(true);
+                        bigBtn.id = '';
+                        bigBtn.classList.add('big-trial-btn');
+                        bigBtn.addEventListener('click', handler);
+                        bigSpot.appendChild(bigBtn);
+                    }
+                }
             });
         }
 
@@ -720,7 +755,12 @@
                 if (kount.ekata && kount.ekata.addressToName) kountLines.push(`<div class="trial-line">Address Name: ${escapeHtml(kount.ekata.addressToName)}</div>`);
             }
 
-            const summary = `<div class="trial-summary"><div class="trial-summary-col"><b>GREEN FLAGS</b><br>${green.join(' ') || 'None'}</div><div class="trial-summary-col"><b>RED FLAGS</b><br>${red.join(' ') || 'None'}</div></div>`;
+            const actions = `
+                <div class="trial-actions">
+                    <button id="trial-btn-cr" class="trial-action-btn trial-btn-cr">C&R</button>
+                    <button id="trial-btn-id" class="trial-action-btn trial-btn-id">ID CONFIRM</button>
+                    <button id="trial-btn-release" class="trial-action-btn trial-btn-release">RELEASE (NO)</button>
+                </div>`;
 
             const orderLines = [];
             if (order) {
@@ -731,13 +771,13 @@
 
             const html = `
                 <div class="trial-close">✕</div>
-                <div class="trial-order"><div class="trial-col">${orderLines.join('')}</div></div>
+                <div class="trial-order"><div class="trial-col">${orderLines.join('')}<span id="trial-big-button"></span></div></div>
                 <div class="trial-columns">
                     <div class="trial-col-wrap"><div class="trial-col-title">DB</div><div class="trial-col">${dbLines.join('')}</div></div>
                     <div class="trial-col-wrap"><div class="trial-col-title">ADYEN</div><div class="trial-col">${adyenLines.join('')}</div></div>
                     <div class="trial-col-wrap"><div class="trial-col-title">KOUNT</div><div class="trial-col">${kountLines.join('')}</div></div>
                 </div>
-                ${summary}
+                ${actions}
             `;
 
             return html;

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -922,3 +922,30 @@
     transform: scale(1.1);
 }
 
+.trial-actions {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 8px;
+}
+
+.trial-action-btn {
+    border: none;
+    border-radius: 6px;
+    padding: 4px 10px;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.trial-btn-cr { background-color: #8B0000; }
+.trial-btn-id { background-color: #800080; }
+.trial-btn-release { background-color: #2ecc71; }
+
+.trial-action-btn:hover { opacity: 0.9; }
+
+.big-trial-btn {
+    font-size: 16px;
+    padding: 6px 14px;
+    margin-left: 8px;
+}
+

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -88,14 +88,27 @@
     padding: 8px;
     border-radius: 8px;
 }
-.fennec-light-mode #fennec-trial-overlay .trial-summary {
+.fennec-light-mode #fennec-trial-overlay .trial-actions {
     display: flex;
     justify-content: space-around;
     margin-top: 8px;
 }
-.fennec-light-mode #fennec-trial-overlay .trial-summary-col {
-    flex: 1;
-    text-align: center;
+.fennec-light-mode #fennec-trial-overlay .trial-action-btn {
+    border: none;
+    border-radius: 6px;
+    padding: 4px 10px;
+    color: #fff;
+    font-weight: bold;
+    cursor: pointer;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-btn-cr { background-color: #8B0000; }
+.fennec-light-mode #fennec-trial-overlay .trial-btn-id { background-color: #800080; }
+.fennec-light-mode #fennec-trial-overlay .trial-btn-release { background-color: #2ecc71; }
+.fennec-light-mode #fennec-trial-overlay .trial-action-btn:hover { opacity: 0.9; }
+.fennec-light-mode #fennec-trial-overlay .big-trial-btn {
+    font-size: 16px;
+    padding: 6px 14px;
+    margin-left: 8px;
 }
 .fennec-light-mode .copilot-tag {
     background-color: #000;


### PR DESCRIPTION
## Summary
- swap green/red flag summary for action buttons
- let the trial floater trigger DB buttons for C&R, ID CONFIRM and RELEASE
- show a big action button next to the company name based on the number of failed checks
- style the new trial floater buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d30565548832689d004a84edc83f5