### PR TITLE
Fix trial header colors

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -458,6 +458,10 @@
             const summary = document.getElementById('fraud-summary-box');
             if (summary) summary.remove();
             chrome.storage.local.get({ adyenDnaInfo: null, kountInfo: null, sidebarOrderInfo: null }, data => {
+                if (!data.adyenDnaInfo && retries > 0) {
+                    setTimeout(() => showTrialFloater(retries - 1, force), 1000);
+                    return;
+                }
                 const html = buildTrialHtml(data.adyenDnaInfo, data.kountInfo, data.sidebarOrderInfo);
                 if (!html) {
                     setTimeout(() => showTrialFloater(retries - 1, force), 1000);
@@ -535,6 +539,10 @@
 
                 const crossCount = overlay.querySelectorAll('.db-adyen-cross').length;
                 const bigSpot = overlay.querySelector('#trial-big-button');
+                let headerCls = 'trial-header-green';
+                if (crossCount > 4) headerCls = 'trial-header-red';
+                else if (crossCount > 0) headerCls = 'trial-header-purple';
+                title.className = 'trial-title ' + headerCls;
                 if (bigSpot) {
                     let srcBtn = relBtn;
                     let handler = () => clickDbAction('.remove-potential-fraud');

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -952,3 +952,7 @@
     margin-left: 8px;
 }
 
+.trial-header-green { background-color: rgba(46,204,113,0.3); }
+.trial-header-purple { background-color: rgba(128,0,128,0.3); }
+.trial-header-red { background-color: rgba(139,0,0,0.3); }
+

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -112,6 +112,9 @@
     padding: 6px 14px;
     margin-left: 8px;
 }
+.fennec-light-mode .trial-header-green { background-color: rgba(46,204,113,0.3); }
+.fennec-light-mode .trial-header-purple { background-color: rgba(128,0,128,0.3); }
+.fennec-light-mode .trial-header-red { background-color: rgba(139,0,0,0.3); }
 .fennec-light-mode .copilot-tag {
     background-color: #000;
     color: #fff !important;


### PR DESCRIPTION
## Summary
- color the Trial floater header based on score
- wait until Adyen data loads before building Trial floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d37941e30832697b62087e82d9d3d