### PR TITLE
Fix XRAY flow to search orders in DB

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Family Tree detects duplicate orders in review, processing or hold and adds a ❌ icon to cancel and refund them.
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
+- XRAY flow opens the DB order search page with the client's email instead of a Gmail search tab.
 - Added a brief delay after selecting the payment type so the page registers **Client Account** reliably.
 - Activating Review Mode from the popup now reloads DB pages so the sidebar appears automatically.
 - The Fraud tracker page also reloads so Review Mode shows the sidebar.

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -642,7 +642,11 @@
                             }
                             if (client.email) parts.push(`"${client.email}"`);
                             if (client.name) parts.push(`"${client.name}"`);
-                            if (parts.length) {
+                            if (parts.length && client.email) {
+                                const base = 'https://db.incfile.com/order-tracker/orders/order-search';
+                                const url = base + '?fennec_email=' + encodeURIComponent(client.email);
+                                chrome.runtime.sendMessage({ action: 'openActiveTab', url });
+                            } else if (parts.length) {
                                 const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
                                 const url = 'https://mail.google.com/mail/u/0/#search/' + query;
                                 chrome.runtime.sendMessage({ action: 'openActiveTab', url });
@@ -2785,7 +2789,11 @@ function getLastHoldUser() {
         }
         if (client.email) parts.push(`"${client.email}"`);
         if (client.name) parts.push(`"${client.name}"`);
-        if (parts.length) {
+        if (client.email) {
+            const base = 'https://db.incfile.com/order-tracker/orders/order-search';
+            const url = base + '?fennec_email=' + encodeURIComponent(client.email);
+            chrome.runtime.sendMessage({ action: 'openTab', url, active: true });
+        } else if (parts.length) {
             const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
             const gmailUrl = 'https://mail.google.com/mail/u/0/#search/' + query;
             chrome.runtime.sendMessage({ action: 'openTab', url: gmailUrl, active: true });


### PR DESCRIPTION
## Summary
- search for email on DB order search page instead of Gmail when launching QA Emails
- open the same DB search during XRAY flow
- document DB search step in changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d3a7cc0e483269a85a427f85a77d4