### PR TITLE
Fix trial floater colors and add success message

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -540,12 +540,28 @@
                         }
                     }
                 }
+                function showTrialSuccess() {
+                    const msg = document.createElement('div');
+                    msg.className = 'trial-success-msg';
+                    msg.textContent = 'Decision saved';
+                    document.body.appendChild(msg);
+                    setTimeout(() => { msg.remove(); }, 2000);
+                }
+
+                function handleTrialAction(selector) {
+                    clickDbAction(selector);
+                    overlay.remove();
+                    title.remove();
+                    clearSidebar();
+                    showTrialSuccess();
+                }
+
                 const crBtn = overlay.querySelector('#trial-btn-cr');
-                if (crBtn) crBtn.addEventListener('click', () => clickDbAction('.cancel-and-refund-potential-fraud'));
+                if (crBtn) crBtn.addEventListener('click', () => handleTrialAction('.cancel-and-refund-potential-fraud'));
                 const idBtn = overlay.querySelector('#trial-btn-id');
-                if (idBtn) idBtn.addEventListener('click', () => clickDbAction('.confirm-fraud-potential-fraud'));
+                if (idBtn) idBtn.addEventListener('click', () => handleTrialAction('.confirm-fraud-potential-fraud'));
                 const relBtn = overlay.querySelector('#trial-btn-release');
-                if (relBtn) relBtn.addEventListener('click', () => clickDbAction('.remove-potential-fraud'));
+                if (relBtn) relBtn.addEventListener('click', () => handleTrialAction('.remove-potential-fraud'));
 
                 const crossCount = overlay.querySelectorAll('.db-adyen-cross').length;
                 const bigSpot = overlay.querySelector('#trial-big-button');
@@ -557,19 +573,19 @@
                 overlay.classList.add(headerCls);
                 if (bigSpot) {
                     let srcBtn = relBtn;
-                    let handler = () => clickDbAction('.remove-potential-fraud');
+                    let selector = '.remove-potential-fraud';
                     if (crossCount > 4) {
                         srcBtn = crBtn;
-                        handler = () => clickDbAction('.cancel-and-refund-potential-fraud');
+                        selector = '.cancel-and-refund-potential-fraud';
                     } else if (crossCount > 0) {
                         srcBtn = idBtn;
-                        handler = () => clickDbAction('.confirm-fraud-potential-fraud');
+                        selector = '.confirm-fraud-potential-fraud';
                     }
                     if (srcBtn) {
                         const bigBtn = srcBtn.cloneNode(true);
                         bigBtn.id = '';
                         bigBtn.classList.add('big-trial-btn');
-                        bigBtn.addEventListener('click', handler);
+                        bigBtn.addEventListener('click', () => handleTrialAction(selector));
                         bigSpot.appendChild(bigBtn);
                     }
                 }

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -955,6 +955,23 @@
     margin-left: 8px;
 }
 
+#fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.3); }
+#fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.3); }
+#fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.3); }
+
+.trial-success-msg {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.8);
+    color: #0f0;
+    padding: 8px 16px;
+    border-radius: 8px;
+    z-index: 1066;
+    font-weight: bold;
+}
+
 #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.3); }
 #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.3); }
 #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.3); }

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -115,6 +115,22 @@
     padding: 6px 14px;
     margin-left: 8px;
 }
+.fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.3); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.3); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.3); }
+
+.fennec-light-mode .trial-success-msg {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.8);
+    color: #0a0;
+    padding: 8px 16px;
+    border-radius: 8px;
+    z-index: 1066;
+    font-weight: bold;
+}
 .fennec-light-mode #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.3); }
 .fennec-light-mode #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.3); }
 .fennec-light-mode #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.3); }


### PR DESCRIPTION
## Summary
- tint trial floater overlay header depending on decision color
- show short success notice when a trial decision is taken
- clear sidebar after taking an action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d4a061b408326a8bfea0882b8fe74