### PR TITLE
Update fraud review UI elements

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -389,6 +389,32 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
 
+    if (message.action === "countOrdersByEmail" && message.email && sender.tab) {
+        const originTab = sender.tab.id;
+        let base = "https://db.incfile.com";
+        try {
+            const url = new URL(sender.tab.url);
+            if (url.hostname.endsWith("incfile.com")) base = url.origin;
+        } catch (err) {
+            console.warn("[Copilot] Invalid sender URL", sender.tab.url);
+        }
+        const url = `${base}/order-tracker/orders/order-search?fennec_email=${encodeURIComponent(message.email)}`;
+        chrome.tabs.create({ url, active: false, windowId: sender.tab.windowId }, tab => {
+            if (chrome.runtime.lastError || !tab) { sendResponse(null); return; }
+            const resultListener = (msg, snd) => {
+                if (msg.action === 'dbEmailSearchResults' && snd.tab && snd.tab.id === tab.id) {
+                    chrome.runtime.onMessage.removeListener(resultListener);
+                    const orders = msg.orders || [];
+                    chrome.tabs.remove(tab.id);
+                    chrome.tabs.update(originTab, { active: true });
+                    sendResponse({ orderCount: orders.length });
+                }
+            };
+            chrome.runtime.onMessage.addListener(resultListener);
+        });
+        return true;
+    }
+
     if (message.action === "detectSubscriptions" && message.email && sender.tab) {
         const originTab = sender.tab.id;
         let base = "https://db.incfile.com";

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -1461,9 +1461,17 @@
             summaryParts.push(...addrEntries);
         }
 
+        // RA/VA line
+        const raTxt = raExpired ? 'EXPIRED' : (hasRA ? 'Sí' : 'No');
+        summaryParts.unshift(
+            `<div style="margin-left:10px"><span class="${raClass}">RA: ${raTxt}</span> ` +
+            `<span class="${vaClass}">VA: ${hasVA ? 'Sí' : 'No'}</span></div>`
+        );
+
         const quickSection = `
             <div class="white-box quick-summary-content" id="quick-summary" style="margin-bottom:10px">
                 ${summaryParts.join('')}
+                <div id="order-count-line" style="margin-left:10px"></div>
             </div>
         `;
         html += quickSection;
@@ -1820,6 +1828,14 @@
             initMistralChat();
             updateReviewDisplay();
             checkLastIssue(orderInfo.orderId);
+            if (client && client.email) {
+                chrome.runtime.sendMessage({ action: 'countOrdersByEmail', email: client.email }, resp => {
+                    if (resp && typeof resp.orderCount === 'number') {
+                        const el = document.getElementById('order-count-line');
+                        if (el) el.textContent = `Orders found: ${resp.orderCount}`;
+                    }
+                });
+            }
             if (miscMode) {
                 setTimeout(autoOpenFamilyTree, 100);
             }

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -801,13 +801,17 @@
             const orderLines = [];
             if (order) {
                 if (order.companyName) orderLines.push(`<div class="trial-line trial-company-name">${escapeHtml(order.companyName)}</div>`);
-                if (order.type) orderLines.push(`<div class="trial-line">${escapeHtml(order.type)}</div>`);
+                if (order.type) {
+                    let typeTxt = escapeHtml(order.type);
+                    if (order.expedited) typeTxt += ' • EXPEDITED';
+                    orderLines.push(`<div class="trial-line">${typeTxt}</div>`);
+                }
                 if (order.orderCost) orderLines.push(`<div class="trial-line">${escapeHtml(order.orderCost)}</div>`);
             }
 
             const html = `
-                <div class="trial-close">✕</div>
-                <div class="trial-order"><div class="trial-col">${orderLines.join('')}<span id="trial-big-button"></span></div></div>
+                <div class="trial-header"><div class="trial-close">✕</div>
+                <div class="trial-order"><div class="trial-col">${orderLines.join('')}<span id="trial-big-button"></span></div></div></div>
                 <div class="trial-columns">
                     <div class="trial-col-wrap"><div class="trial-col-title">DB</div><div class="trial-col">${dbLines.join('')}</div></div>
                     <div class="trial-col-wrap"><div class="trial-col-title">ADYEN</div><div class="trial-col">${adyenLines.join('')}</div></div>

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -765,6 +765,10 @@
     font-weight: bold;
     color: #fff;
 }
+#fennec-trial-overlay .trial-header {
+    position: relative;
+    margin-bottom: 8px;
+}
 #fennec-trial-overlay .trial-columns {
     display: flex;
     gap: 12px;
@@ -772,7 +776,6 @@
 }
 #fennec-trial-overlay .trial-order {
     text-align: center;
-    margin-bottom: 8px;
 }
 #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
@@ -955,9 +958,9 @@
     margin-left: 8px;
 }
 
-#fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.3); }
-#fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-#fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.3); }
+#fennec-trial-overlay.trial-header-green .trial-header { background-color: rgba(46,204,113,0.3); }
+#fennec-trial-overlay.trial-header-purple .trial-header { background-color: rgba(128,0,128,0.3); }
+#fennec-trial-overlay.trial-header-red .trial-header { background-color: rgba(139,0,0,0.3); }
 
 .trial-success-msg {
     position: fixed;


### PR DESCRIPTION
## Summary
- highlight only the header of the trial floater
- include EXPEDITED info on trial orders
- show RA/VA together in DB quick summary and fetch order counts from email search
- support order count retrieval in background service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d4c82c2488326a0232a2a83414e10