### PR TITLE
Adjust trial header transparency and reuse search tab

### DIFF
--- a/FENNEC/environments/db/db_email_search.js
+++ b/FENNEC/environments/db/db_email_search.js
@@ -4,6 +4,17 @@
         const params = new URLSearchParams(location.search);
         const email = params.get('fennec_email');
         if (!email) return;
+        function collectOrders() {
+            const rows = document.querySelectorAll('.search_result tbody tr');
+            return Array.from(rows).map(r => {
+                const link = r.querySelector('a[href*="/order/detail/"]');
+                const id = link ? link.textContent.replace(/\D+/g, '') : '';
+                const typeCell = r.querySelector('td:nth-child(4)');
+                const type = typeCell ? typeCell.textContent.trim() : '';
+                return { orderId: id, type };
+            });
+        }
+
         function run() {
             const input = document.querySelector('#search_field');
             if (input) {
@@ -15,13 +26,7 @@
             const gather = () => {
                 const rows = document.querySelectorAll('.search_result tbody tr');
                 if (!rows.length) { setTimeout(gather, 500); return; }
-                const orders = Array.from(rows).map(r => {
-                    const link = r.querySelector('a[href*="/order/detail/"]');
-                    const id = link ? link.textContent.replace(/\D+/g, '') : '';
-                    const typeCell = r.querySelector('td:nth-child(4)');
-                    const type = typeCell ? typeCell.textContent.trim() : '';
-                    return { orderId: id, type };
-                });
+                const orders = collectOrders();
                 chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
             };
             gather();
@@ -29,5 +34,11 @@
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', run);
         } else run();
+
+        chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
+            if (msg.action === 'getEmailOrders') {
+                sendResponse({ orders: collectOrders() });
+            }
+        });
     });
 })();

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -775,13 +775,13 @@
     margin-bottom: 8px;
 }
 #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
-    background-color: rgba(46,204,113,0.3);
+    background-color: rgba(46,204,113,0.02);
 }
 #fennec-trial-overlay .trial-order.trial-header-purple .trial-col {
-    background-color: rgba(128,0,128,0.3);
+    background-color: rgba(128,0,128,0.02);
 }
 #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
-    background-color: rgba(139,0,0,0.3);
+    background-color: rgba(139,0,0,0.02);
 }
 #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
@@ -964,9 +964,9 @@
     margin-left: 8px;
 }
 
-#fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.3); }
-#fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-#fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.3); }
+#fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.02); }
+#fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.02); }
+#fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.02); }
 
 .trial-success-msg {
     position: fixed;
@@ -981,11 +981,11 @@
     font-weight: bold;
 }
 
-#fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.3); }
-#fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-#fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.3); }
+#fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.02); }
+#fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.02); }
+#fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.02); }
 
-.trial-header-green { background-color: rgba(46,204,113,0.3); }
-.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-.trial-header-red { background-color: rgba(139,0,0,0.3); }
+.trial-header-green { background-color: rgba(46,204,113,0.02); }
+.trial-header-purple { background-color: rgba(128,0,128,0.02); }
+.trial-header-red { background-color: rgba(139,0,0,0.02); }
 

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -76,13 +76,13 @@
     margin-bottom: 8px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
-    background-color: rgba(46,204,113,0.3);
+    background-color: rgba(46,204,113,0.02);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-purple .trial-col {
-    background-color: rgba(128,0,128,0.3);
+    background-color: rgba(128,0,128,0.02);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
-    background-color: rgba(139,0,0,0.3);
+    background-color: rgba(139,0,0,0.02);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
@@ -124,9 +124,9 @@
     padding: 6px 14px;
     margin-left: 8px;
 }
-.fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.3); }
-.fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-.fennec-light-mode #fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.3); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.02); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.02); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.02); }
 
 .fennec-light-mode .trial-success-msg {
     position: fixed;
@@ -140,12 +140,12 @@
     z-index: 1066;
     font-weight: bold;
 }
-.fennec-light-mode #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.3); }
-.fennec-light-mode #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.3); }
-.fennec-light-mode #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.3); }
-.fennec-light-mode .trial-header-green { background-color: rgba(46,204,113,0.3); }
-.fennec-light-mode .trial-header-purple { background-color: rgba(128,0,128,0.3); }
-.fennec-light-mode .trial-header-red { background-color: rgba(139,0,0,0.3); }
+.fennec-light-mode #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.02); }
+.fennec-light-mode #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.02); }
+.fennec-light-mode #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.02); }
+.fennec-light-mode .trial-header-green { background-color: rgba(46,204,113,0.02); }
+.fennec-light-mode .trial-header-purple { background-color: rgba(128,0,128,0.02); }
+.fennec-light-mode .trial-header-red { background-color: rgba(139,0,0,0.02); }
 .fennec-light-mode .copilot-tag {
     background-color: #000;
     color: #fff !important;


### PR DESCRIPTION
## Summary
- lighten Trial floater headers with 98% transparency
- allow DB email search scripts to return order counts on demand
- reuse the opened DB search tab to retrieve order totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d51418600832685709e4d70598f71