### PR TITLE
Improve Fraud Review trial header and DB info

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -398,6 +398,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
                 return;
             }
+            chrome.tabs.update(searchTab.id, { active: true });
             chrome.tabs.sendMessage(searchTab.id, { action: 'getEmailOrders' }, resp => {
                 if (chrome.runtime.lastError || !resp) {
                     sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -569,6 +569,8 @@
                 if (crossCount > 4) headerCls = 'trial-header-red';
                 else if (crossCount > 0) headerCls = 'trial-header-purple';
                 title.className = 'trial-title ' + headerCls;
+                overlay.classList.remove('trial-header-green','trial-header-purple','trial-header-red');
+                overlay.classList.add(headerCls);
                 const orderHeader = overlay.querySelector('.trial-order');
                 if (orderHeader) {
                     orderHeader.classList.remove('trial-header-green','trial-header-purple','trial-header-red');

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -755,6 +755,7 @@
     width: 840px;
     padding: 4px 0;
     border-radius: 6px;
+    font-size: calc(var(--sb-font-size) + 2px);
 }
 
 #fennec-trial-overlay .trial-close {


### PR DESCRIPTION
## Summary
- enlarge and color-code the trial overlay header
- color the entire overlay based on the fraud result
- activate DB search tab before reading order data

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d54d72c9083269f289b2b8e0f44a5