### PR TITLE
Fix fraud review floater when DNA loads slowly

### DIFF
--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -487,7 +487,9 @@
 
             function handleDnaPage() {
                 console.log('[FENNEC Adyen] Extracting DNA page stats');
-                waitForElement('.data-breakdown .item').then(() => {
+                // Large DNA pages can take a while to render all stats,
+                // so allow a longer wait time before giving up.
+                waitForElement('.data-breakdown .item', 30000).then(() => {
                     const stats = {};
                     document.querySelectorAll('.stats-bar-item').forEach(item => {
                         const label = item.querySelector('.stats-bar-item__label');

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -451,7 +451,9 @@
 
         // Displays the floating TRIAL SUMMARY once XRAY data is available.
         // Allow a few extra retries in case Kount or Adyen info is delayed.
-        function showTrialFloater(retries = 10, force = false) {
+        // DNA info may take a while to load for very large records.
+        // Increase retries so the trial floater still appears.
+        function showTrialFloater(retries = 20, force = false) {
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
             const overlayExists = document.getElementById('fennec-trial-overlay');
             if ((!flag && !force && !overlayExists) || retries <= 0) return;
@@ -977,13 +979,13 @@
                 loadKountSummary();
             }
             if (area === 'local' && (changes.adyenDnaInfo || changes.kountInfo)) {
-                showTrialFloater(10, true);
+                showTrialFloater(20, true);
             }
         });
         window.addEventListener('focus', () => {
             loadDnaSummary();
             loadKountSummary();
-            showTrialFloater(10, true);
+            showTrialFloater(20, true);
         });
     });
 })();


### PR DESCRIPTION
## Summary
- wait longer on Adyen DNA pages before collecting stats
- increase retry count when waiting for DNA info to build the Fraud Review floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d578c3e408326a35115f1206d4b5e