### PR TITLE
Update trial floater transparency and focus

### DIFF
--- a/FENNEC/environments/db/db_email_search.js
+++ b/FENNEC/environments/db/db_email_search.js
@@ -27,7 +27,7 @@
                 const rows = document.querySelectorAll('.search_result tbody tr');
                 if (!rows.length) { setTimeout(gather, 500); return; }
                 const orders = collectOrders();
-                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
+                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders }, () => { chrome.runtime.sendMessage({ action: 'refocusTab' }); });
             };
             gather();
         }

--- a/FENNEC/environments/db/db_order_search.js
+++ b/FENNEC/environments/db/db_order_search.js
@@ -29,7 +29,7 @@
                 const rows = document.querySelectorAll('.search_result tbody tr');
                 if (!rows.length) { setTimeout(gather, 500); return; }
                 const orders = collectOrders();
-                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
+                chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders }, () => { chrome.runtime.sendMessage({ action: 'refocusTab' }); });
             };
             gather();
         }

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -734,7 +734,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background-color: var(--sb-box-bg, #2e2e2e);
+    background-color: rgba(46,46,46,0.98);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -755,7 +755,7 @@
     width: 840px;
     padding: 4px 0;
     border-radius: 6px;
-    font-size: calc(var(--sb-font-size) + 2px);
+    font-size: calc(var(--sb-font-size) + 4px) !important;
 }
 
 #fennec-trial-overlay .trial-close {
@@ -776,13 +776,13 @@
     margin-bottom: 8px;
 }
 #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
-    background-color: rgba(46,204,113,0.02);
+    background-color: rgba(46,204,113,0.99);
 }
 #fennec-trial-overlay .trial-order.trial-header-purple .trial-col {
-    background-color: rgba(128,0,128,0.02);
+    background-color: rgba(128,0,128,0.99);
 }
 #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
-    background-color: rgba(139,0,0,0.02);
+    background-color: rgba(139,0,0,0.99);
 }
 #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
@@ -965,9 +965,9 @@
     margin-left: 8px;
 }
 
-#fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.02); }
-#fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.02); }
-#fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.02); }
+#fennec-trial-overlay.trial-header-green { background-color: rgba(46,46,46,0.98); }
+#fennec-trial-overlay.trial-header-purple { background-color: rgba(46,46,46,0.98); }
+#fennec-trial-overlay.trial-header-red { background-color: rgba(46,46,46,0.98); }
 
 .trial-success-msg {
     position: fixed;
@@ -982,11 +982,11 @@
     font-weight: bold;
 }
 
-#fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.02); }
-#fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.02); }
-#fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.02); }
+#fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.99); }
+#fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.99); }
+#fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.99); }
 
-.trial-header-green { background-color: rgba(46,204,113,0.02); }
-.trial-header-purple { background-color: rgba(128,0,128,0.02); }
-.trial-header-red { background-color: rgba(139,0,0,0.02); }
+.trial-header-green { background-color: rgba(46,204,113,0.99); }
+.trial-header-purple { background-color: rgba(128,0,128,0.99); }
+.trial-header-red { background-color: rgba(139,0,0,0.99); }
 

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -46,7 +46,7 @@
     color: #0000ee;
 }
 .fennec-light-mode #fennec-trial-overlay {
-    background-color: #fff;
+    background-color: rgba(255,255,255,0.98);
     color: #000 !important;
     border: 1px solid #777;
     width: 840px;
@@ -65,6 +65,7 @@
     width: 840px;
     padding: 4px 0;
     border-radius: 6px;
+    font-size: calc(var(--sb-font-size) + 4px) !important;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-columns {
     display: flex;
@@ -76,13 +77,13 @@
     margin-bottom: 8px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
-    background-color: rgba(46,204,113,0.02);
+    background-color: rgba(46,204,113,0.99);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-purple .trial-col {
-    background-color: rgba(128,0,128,0.02);
+    background-color: rgba(128,0,128,0.99);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
-    background-color: rgba(139,0,0,0.02);
+    background-color: rgba(139,0,0,0.99);
 }
 .fennec-light-mode #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
@@ -124,9 +125,9 @@
     padding: 6px 14px;
     margin-left: 8px;
 }
-.fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(46,204,113,0.02); }
-.fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(128,0,128,0.02); }
-.fennec-light-mode #fennec-trial-overlay.trial-header-red { background-color: rgba(139,0,0,0.02); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(255,255,255,0.98); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(255,255,255,0.98); }
+.fennec-light-mode #fennec-trial-overlay.trial-header-red { background-color: rgba(255,255,255,0.98); }
 
 .fennec-light-mode .trial-success-msg {
     position: fixed;
@@ -140,12 +141,12 @@
     z-index: 1066;
     font-weight: bold;
 }
-.fennec-light-mode #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.02); }
-.fennec-light-mode #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.02); }
-.fennec-light-mode #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.02); }
-.fennec-light-mode .trial-header-green { background-color: rgba(46,204,113,0.02); }
-.fennec-light-mode .trial-header-purple { background-color: rgba(128,0,128,0.02); }
-.fennec-light-mode .trial-header-red { background-color: rgba(139,0,0,0.02); }
+.fennec-light-mode #fennec-trial-title.trial-header-green { background-color: rgba(46,204,113,0.99); }
+.fennec-light-mode #fennec-trial-title.trial-header-purple { background-color: rgba(128,0,128,0.99); }
+.fennec-light-mode #fennec-trial-title.trial-header-red { background-color: rgba(139,0,0,0.99); }
+.fennec-light-mode .trial-header-green { background-color: rgba(46,204,113,0.99); }
+.fennec-light-mode .trial-header-purple { background-color: rgba(128,0,128,0.99); }
+.fennec-light-mode .trial-header-red { background-color: rgba(139,0,0,0.99); }
 .fennec-light-mode .copilot-tag {
     background-color: #000;
     color: #fff !important;


### PR DESCRIPTION
## Summary
- update trial floater background to 98% opacity of default background
- style trial headers with 99% opacity colors and larger font
- refocus to FRAUD REVIEW tab after DB email search gathers orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d5a18d7ac8326b41b7b050638b5b5