### PR TITLE
Ensure XRAY sidebar view persists across tabs

### DIFF
--- a/FENNEC/core/utils.js
+++ b/FENNEC/core/utils.js
@@ -41,6 +41,23 @@ function abbreviateOrderType(type) {
 }
 window.abbreviateOrderType = abbreviateOrderType;
 
+function storeSidebarSnapshot(sidebar) {
+    if (!sidebar) return;
+    chrome.storage.local.set({ sidebarSnapshot: sidebar.innerHTML });
+}
+window.storeSidebarSnapshot = storeSidebarSnapshot;
+
+function loadSidebarSnapshot(sidebar) {
+    if (!sidebar) return;
+    chrome.storage.local.get({ sidebarSnapshot: null }, ({ sidebarSnapshot }) => {
+        if (sidebarSnapshot) {
+            sidebar.innerHTML = sidebarSnapshot;
+            attachCommonListeners(sidebar);
+        }
+    });
+}
+window.loadSidebarSnapshot = loadSidebarSnapshot;
+
 function attachCommonListeners(rootEl) {
     if (!rootEl) return;
     rootEl.querySelectorAll('.copilot-address').forEach(el => {

--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -298,6 +298,7 @@
                         const html = buildDnaHtml(adyenDnaInfo);
                         container.innerHTML = html || '';
                         attachCommonListeners(container);
+                        if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
                     });
                 });
             }
@@ -310,6 +311,7 @@
                         container.innerHTML = sidebarDb.join('');
                         container.style.display = 'block';
                         attachCommonListeners(container);
+                        if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
                         const qbox = container.querySelector('#quick-summary');
                         if (qbox) {
                             qbox.classList.remove('quick-summary-collapsed');
@@ -344,6 +346,7 @@
                     label.textContent = '';
                     label.className = 'issue-status-label';
                 }
+                if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
             }
 
             function checkLastIssue(orderId) {
@@ -386,7 +389,8 @@
                     sidebarOrderId: null,
                     sidebarOrderInfo: null,
                     adyenDnaInfo: null,
-                    sidebarFreezeId: null
+                    sidebarFreezeId: null,
+                    sidebarSnapshot: null
                 });
                 showInitialStatus();
             }
@@ -421,6 +425,7 @@
                     sidebarBgColor: '#212121',
                     sidebarBoxColor: '#2e2e2e'
                 }, opts => applySidebarDesign(sidebar, opts));
+                loadSidebarSnapshot(sidebar);
                 document.body.style.marginRight = '340px';
                 const closeBtn = sidebar.querySelector('#copilot-close');
                 if (closeBtn) {
@@ -532,6 +537,7 @@
             }
 
             const path = window.location.pathname;
+            const isDnaPage = path.includes('showOilSplashList.shtml');
             console.log('[FENNEC Adyen] Path:', path);
             const ready = document.readyState === 'loading' ? 'DOMContentLoaded' : null;
             if (ready) {
@@ -578,6 +584,13 @@
             chrome.storage.onChanged.addListener((changes, area) => {
                 if (area === 'local' && changes.sidebarDb) loadDbSummary();
                 if (area === 'local' && changes.adyenDnaInfo) loadDnaSummary();
+                if (area === 'local' && changes.sidebarSnapshot && changes.sidebarSnapshot.newValue) {
+                    const sb = document.getElementById('copilot-sidebar');
+                    if (sb) {
+                        sb.innerHTML = changes.sidebarSnapshot.newValue;
+                        attachCommonListeners(sb);
+                    }
+                }
             });
         } catch (e) {
             console.error('[FENNEC Adyen] Launcher error:', e);

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -511,6 +511,7 @@
                         sidebarBgColor: '#212121',
                         sidebarBoxColor: '#2e2e2e'
                     }, opts => applySidebarDesign(sidebar, opts));
+                    loadSidebarSnapshot(sidebar);
 
                     updateReviewDisplay();
                     const closeBtn = sidebar.querySelector('#copilot-close');
@@ -2093,7 +2094,8 @@
             sidebarOrderId: null,
             sidebarOrderInfo: null,
             adyenDnaInfo: null,
-            sidebarFreezeId: null
+            sidebarFreezeId: null,
+            sidebarSnapshot: null
         });
         const body = document.getElementById('copilot-body-content');
         if (body) body.innerHTML = '<div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>';
@@ -2852,6 +2854,13 @@ chrome.storage.onChanged.addListener((changes, area) => {
     }
     if (area === 'local' && changes.kountInfo) {
         loadKountSummary();
+    }
+    if (area === 'local' && changes.sidebarSnapshot && changes.sidebarSnapshot.newValue) {
+        const sb = document.getElementById('copilot-sidebar');
+        if (sb) {
+            sb.innerHTML = changes.sidebarSnapshot.newValue;
+            attachCommonListeners(sb);
+        }
     }
 });
 

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1278,7 +1278,8 @@
                 sidebarOrderId: null,
                 sidebarOrderInfo: null,
                 adyenDnaInfo: null,
-                sidebarFreezeId: null
+                sidebarFreezeId: null,
+                sidebarSnapshot: null
             });
             showInitialStatus();
             applyReviewMode();
@@ -1375,6 +1376,7 @@
                 sidebarBgColor: '#212121',
                 sidebarBoxColor: '#2e2e2e'
             }, opts => applySidebarDesign(sidebar, opts));
+            loadSidebarSnapshot(sidebar);
 
             console.log("[Copilot] Sidebar INYECTADO en Gmail.");
 
@@ -1443,6 +1445,14 @@
             if (area === 'local' && changes.adyenDnaInfo) {
                 loadDnaSummary();
             loadKountSummary();
+            }
+            if (area === 'local' && changes.sidebarSnapshot && changes.sidebarSnapshot.newValue) {
+                const sb = document.getElementById('copilot-sidebar');
+                if (sb) {
+                    sb.innerHTML = changes.sidebarSnapshot.newValue;
+                    attachCommonListeners(sb);
+                    repositionDnaSummary();
+                }
             }
             if (area === 'sync' && changes.fennecReviewMode) {
                 reviewMode = changes.fennecReviewMode.newValue;


### PR DESCRIPTION
## Summary
- add utilities to store and load a sidebar snapshot
- load stored snapshot when injecting sidebars
- clear snapshot when sidebar is cleared
- broadcast snapshot updates from the Adyen DNA page
- refresh sidebar when snapshot changes on Gmail and DB pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d6108e64c8326a7db8da3033b5d3d