### PR TITLE
Improve fraud trial floater

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -482,8 +482,11 @@
                     overlay.id = 'fennec-trial-overlay';
                     title = document.createElement('div');
                     title.id = 'fennec-trial-title';
-                    title.className = 'trial-title';
                     title.textContent = 'FRAUD REVIEW';
+                    title.style.fontSize = 'calc(var(--sb-font-size) + 18px)';
+                    title.style.padding = '6px 0';
+                    title.style.borderRadius = '12px';
+                    title.style.textShadow = '0 0 2px #fff, 0 0 6px #fff';
                     document.body.appendChild(title);
                     document.body.appendChild(overlay);
                 }
@@ -492,6 +495,7 @@
                 if (close) close.addEventListener('click', () => {
                     overlay.remove();
                     title.remove();
+                    chrome.runtime.sendMessage({ action: 'refocusTab' });
                 });
                 const subBtn = overlay.querySelector('#sub-detection-btn');
                 if (subBtn) {
@@ -560,6 +564,7 @@
                     title.remove();
                     clearSidebar();
                     showTrialSuccess();
+                    chrome.runtime.sendMessage({ action: 'refocusTab' });
                 }
 
                 const crBtn = overlay.querySelector('#trial-btn-cr');
@@ -574,7 +579,7 @@
                 let headerCls = 'trial-header-green';
                 if (crossCount > 4) headerCls = 'trial-header-red';
                 else if (crossCount > 0) headerCls = 'trial-header-purple';
-                title.className = 'trial-title ' + headerCls;
+                title.className = headerCls;
                 overlay.classList.remove('trial-header-green','trial-header-purple','trial-header-red');
                 overlay.classList.add(headerCls);
                 const orderHeader = overlay.querySelector('.trial-order');

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -753,10 +753,10 @@
     color: #fff;
     margin: 0 auto 4px;
     width: 840px;
-    padding: 4px 0;
-    border-radius: 8px;
-    font-size: calc(var(--sb-font-size) + 12px) !important;
-    text-shadow: 0 0 4px #fff;
+    padding: 6px 0;
+    border-radius: 12px;
+    font-size: calc(var(--sb-font-size) + 18px) !important;
+    text-shadow: 0 0 2px #fff, 0 0 6px #fff;
 }
 
 #fennec-trial-overlay .trial-close {


### PR DESCRIPTION
## Summary
- enlarge trial floater title and highlight the text
- store return tab id and refocus after closing trial floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6703f4e4832685146929ae47cb45