### PR TITLE
Improve trial overlay styling and tab focus

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -36,7 +36,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
         });
         if (message.refocus && sender && sender.tab) {
-            chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
+            chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
+                if (!fennecReturnTab) {
+                    chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
+                }
+            });
         }
     }
 
@@ -64,7 +68,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 });
             }
             if (message.refocus && sender && sender.tab) {
-                chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
+                chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
+                    if (!fennecReturnTab) {
+                        chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
+                    }
+                });
             }
         });
         return;
@@ -686,6 +694,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     if (chrome.runtime.lastError) {
                         console.error("[Copilot] Error focusing tab:", chrome.runtime.lastError.message);
                     }
+                    chrome.storage.local.set({ fennecReturnTab: null });
                 });
             }
         });

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -483,10 +483,11 @@
                     title = document.createElement('div');
                     title.id = 'fennec-trial-title';
                     title.textContent = 'FRAUD REVIEW';
-                    title.style.fontSize = 'calc(var(--sb-font-size) + 18px)';
-                    title.style.padding = '6px 0';
-                    title.style.borderRadius = '12px';
-                    title.style.textShadow = '0 0 2px #fff, 0 0 6px #fff';
+                    title.style.setProperty('font-size', 'calc(var(--sb-font-size) + 22px)', 'important');
+                    title.style.setProperty('padding', '6px 0', 'important');
+                    title.style.setProperty('border-radius', '12px', 'important');
+                    title.style.setProperty('text-shadow', '0 0 2px #fff, 0 0 6px #fff', 'important');
+                    title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
                     document.body.appendChild(title);
                     document.body.appendChild(overlay);
                 }

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -755,8 +755,9 @@
     width: 840px;
     padding: 6px 0;
     border-radius: 12px;
-    font-size: calc(var(--sb-font-size) + 18px) !important;
+    font-size: calc(var(--sb-font-size) + 22px) !important;
     text-shadow: 0 0 2px #fff, 0 0 6px #fff;
+    box-shadow: 0 0 0 2px #fff inset;
 }
 
 #fennec-trial-overlay .trial-close {


### PR DESCRIPTION
## Summary
- adjust TRIAL overlay header CSS for larger text and white highlight
- force header styles inline when creating the overlay
- store original tab only once when opening new tabs
- return focus to the saved tab and clear storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d703567c4832681f06ef8478156fa