### PR TITLE
Improve fraud trial floater styling and focus

### DIFF
--- a/FENNEC/core/background_email_search.js
+++ b/FENNEC/core/background_email_search.js
@@ -36,11 +36,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
         });
         if (message.refocus && sender && sender.tab) {
-            chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
-                if (!fennecReturnTab) {
-                    chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
-                }
-            });
+            chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
         }
     }
 
@@ -68,11 +64,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 });
             }
             if (message.refocus && sender && sender.tab) {
-                chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
-                    if (!fennecReturnTab) {
-                        chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
-                    }
-                });
+                chrome.storage.local.set({ fennecReturnTab: sender.tab.id });
             }
         });
         return;

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -73,7 +73,8 @@
         function runXray(orderId) {
             const dbUrl = `https://db.incfile.com/incfile/order/detail/${orderId}?fraud_xray=1`;
             sessionStorage.setItem('fennecShowTrialFloater', '1');
-            chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true, refocus: true });
+            // Do not store return tab for the initial XRAY detail tab
+            chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true });
         }
 
         function addXrayIcon(el, orderId) {
@@ -483,10 +484,12 @@
                     title = document.createElement('div');
                     title.id = 'fennec-trial-title';
                     title.textContent = 'FRAUD REVIEW';
-                    title.style.setProperty('font-size', 'calc(var(--sb-font-size) + 22px)', 'important');
+                    title.style.setProperty('font-size', '35px', 'important');
+                    title.style.setProperty('line-height', '1.2', 'important');
                     title.style.setProperty('padding', '6px 0', 'important');
                     title.style.setProperty('border-radius', '12px', 'important');
-                    title.style.setProperty('text-shadow', '0 0 2px #fff, 0 0 6px #fff', 'important');
+                    title.style.setProperty('text-shadow', '0 0 3px #fff, 0 0 8px #fff', 'important');
+                    title.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
                     title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
                     document.body.appendChild(title);
                     document.body.appendChild(overlay);

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -755,8 +755,10 @@
     width: 840px;
     padding: 6px 0;
     border-radius: 12px;
-    font-size: calc(var(--sb-font-size) + 22px) !important;
-    text-shadow: 0 0 2px #fff, 0 0 6px #fff;
+    font-size: 35px !important;
+    line-height: 1.2;
+    text-shadow: 0 0 3px #fff, 0 0 8px #fff;
+    -webkit-text-stroke: 1px #fff;
     box-shadow: 0 0 0 2px #fff inset;
 }
 

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -66,8 +66,10 @@
     width: 840px;
     padding: 4px 0;
     border-radius: 8px;
-    font-size: calc(var(--sb-font-size) + 12px) !important;
-    text-shadow: 0 0 4px #fff;
+    font-size: 35px !important;
+    line-height: 1.2;
+    text-shadow: 0 0 3px #fff, 0 0 8px #fff;
+    -webkit-text-stroke: 1px #fff;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-columns {
     display: flex;


### PR DESCRIPTION
## Summary
- enlarge the trial floater header text and give it a white outline
- ensure initial XRAY tab doesn't override the return focus tab
- always update refocus tab so closing the trial returns to the right page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7269d0088326ab87f924078627ba