### PR TITLE
Update trial header styling

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -483,13 +483,26 @@
                     title = document.createElement('div');
                     title.id = 'fennec-trial-title';
                     title.textContent = 'FRAUD REVIEW';
-                    title.style.setProperty('font-size', 'calc(var(--sb-font-size) + 22px)', 'important');
-                    title.style.setProperty('padding', '6px 0', 'important');
+                    title.style.setProperty('font-size', 'calc(var(--sb-font-size) + 26px)', 'important');
+                    title.style.setProperty('line-height', '1.2', 'important');
+                    title.style.setProperty('padding', '8px 0', 'important');
                     title.style.setProperty('border-radius', '12px', 'important');
-                    title.style.setProperty('text-shadow', '0 0 2px #fff, 0 0 6px #fff', 'important');
+                    title.style.setProperty('text-shadow', '0 0 4px #fff, 0 0 8px #fff', 'important');
                     title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
+                    title.style.setProperty('background-color', 'inherit', 'important');
+                    title.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
                     document.body.appendChild(title);
                     document.body.appendChild(overlay);
+                } else {
+                    // Ensure header styling persists if overlay already existed
+                    title.style.setProperty('font-size', 'calc(var(--sb-font-size) + 26px)', 'important');
+                    title.style.setProperty('line-height', '1.2', 'important');
+                    title.style.setProperty('padding', '8px 0', 'important');
+                    title.style.setProperty('border-radius', '12px', 'important');
+                    title.style.setProperty('text-shadow', '0 0 4px #fff, 0 0 8px #fff', 'important');
+                    title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
+                    title.style.setProperty('background-color', 'inherit', 'important');
+                    title.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
                 }
                 overlay.innerHTML = html;
                 const close = overlay.querySelector('.trial-close');

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -753,11 +753,13 @@
     color: #fff;
     margin: 0 auto 4px;
     width: 840px;
-    padding: 6px 0;
+    padding: 8px 0;
     border-radius: 12px;
-    font-size: calc(var(--sb-font-size) + 22px) !important;
-    text-shadow: 0 0 2px #fff, 0 0 6px #fff;
+    font-size: calc(var(--sb-font-size) + 26px) !important;
+    line-height: 1.2;
+    text-shadow: 0 0 4px #fff, 0 0 8px #fff;
     box-shadow: 0 0 0 2px #fff inset;
+    -webkit-text-stroke: 1px #fff;
 }
 
 #fennec-trial-overlay .trial-close {

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -64,10 +64,13 @@
     color: #fff;
     margin: 0 auto 4px;
     width: 840px;
-    padding: 4px 0;
-    border-radius: 8px;
-    font-size: calc(var(--sb-font-size) + 12px) !important;
-    text-shadow: 0 0 4px #fff;
+    padding: 8px 0;
+    border-radius: 12px;
+    font-size: calc(var(--sb-font-size) + 26px) !important;
+    line-height: 1.2;
+    text-shadow: 0 0 4px #fff, 0 0 8px #fff;
+    box-shadow: 0 0 0 2px #fff inset;
+    -webkit-text-stroke: 1px #fff;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-columns {
     display: flex;


### PR DESCRIPTION
## Summary
- ensure Fraud Review Trial header enforces large style inline
- bump header font size, add stroke and shadows in sidebar CSS
- same header updates for light theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d75fbff2c832690b7bd26a2863994