### PR TITLE
Implement XRAY email search focus

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -151,3 +151,4 @@
 - XRAY now opens the Kount workflow page when a Kount link is present on the DB page.
 - Kount summary box displays email age, device location and Ekata results below DNA.
 - CVV tags in DB SB Fraud Review correctly detect "Matches (M)" and the Fraud Review summary reappears after using CLEAR.
+- After DNA loads during the FRAUD REVIEW XRAY flow, focus switches to the DB email search tab until results load, then returns to the Fraud tracker.

--- a/FENNEC/README.md
+++ b/FENNEC/README.md
@@ -205,7 +205,8 @@ ICONS/BUTTONS/FUNCTIONS:
    2. DNA
    Focus returns to the original email once information is retrieved.
 🩻 XRAY: Runs SEARCH and DNA operations one after the other and opens the Kount workflow page when available.
-   Focus also returns to the original email at the end.
+   After DNA loads the extension switches to the DB email search tab until results appear,
+   then focus returns to the original email at the end.
    A KOUNT summary box appears below DNA after the data is extracted.
 🤖 FILE: Automator that opens and fills the SOS filing process.
 

--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -532,7 +532,10 @@
                     const networkTx = extractNetworkTransactions();
                     saveData({ transactions: stats, networkTransactions: networkTx, updated: Date.now() });
                     console.log('[FENNEC Adyen] DNA stats stored');
-                    chrome.runtime.sendMessage({ action: 'refocusTab' });
+                    chrome.storage.local.get({ sidebarOrderInfo: null }, ({ sidebarOrderInfo }) => {
+                        const email = sidebarOrderInfo ? sidebarOrderInfo.clientEmail : null;
+                        chrome.runtime.sendMessage({ action: 'focusDbSearch', email });
+                    });
                 });
             }
 


### PR DESCRIPTION
## Summary
- focus DB email search results after DNA page loads
- return focus to fraud tracker when results arrive
- document the new XRAY flow in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7a2b02f88326b75cbe8e34df8e34