### PR TITLE
Update trial floater header

### DIFF
--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -866,20 +866,24 @@
 
             const orderLines = [];
             if (order) {
-                if (order.companyName) orderLines.push(`<div class="trial-line trial-company-name">${escapeHtml(order.companyName)}</div>`);
-                if (order.type) {
-                    let typeText = escapeHtml(order.type);
-                    if (typeof order.expedited === 'boolean') {
-                        typeText += order.expedited ? ' (EXPEDITED)' : ' (NOT EXPEDITED)';
-                    }
-                    orderLines.push(`<div class="trial-line">${typeText}</div>`);
+                if (order.companyName) {
+                    orderLines.push(`<div class="trial-line trial-company-name">${escapeHtml(order.companyName)}</div>`);
                 }
-                if (order.orderCost) orderLines.push(`<div class="trial-line">${escapeHtml(order.orderCost)}</div>`);
+                const tags = [];
+                if (order.type) tags.push(`<span class="copilot-tag copilot-tag-lightgray">${escapeHtml(order.type)}</span>`);
+                if (typeof order.expedited === 'boolean') {
+                    tags.push(`<span class="copilot-tag copilot-tag-lightgray">${order.expedited ? 'EXPEDITED' : 'STANDARD'}</span>`);
+                }
+                if (order.orderCost) tags.push(`<span class="copilot-tag copilot-tag-lightgray">${escapeHtml(order.orderCost)}</span>`);
+                if (tags.length) {
+                    orderLines.push(`<div class="trial-line trial-tags">${tags.join(' ')}</div>`);
+                }
+                orderLines.push(`<div class="trial-line trial-btn-line"><span id="trial-big-button"></span></div>`);
             }
 
             const html = `
                 <div class="trial-close">✕</div>
-                <div class="trial-order"><div class="trial-col">${orderLines.join('')}<span id="trial-big-button"></span></div></div>
+                <div class="trial-order"><div class="trial-col">${orderLines.join('')}</div></div>
                 <div class="trial-columns">
                     <div class="trial-col-wrap"><div class="trial-col-title">DB</div><div class="trial-col">${dbLines.join('')}</div></div>
                     <div class="trial-col-wrap"><div class="trial-col-title">ADYEN</div><div class="trial-col">${adyenLines.join('')}</div></div>

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -783,7 +783,7 @@
     border-radius: 12px;
 }
 #fennec-trial-overlay .trial-order .trial-line {
-    font-size: calc(var(--sb-font-size) + 4px);
+    font-size: calc(var(--sb-font-size) + 6px);
     background: rgba(255,255,255,0.9);
     color: #000;
     padding: 2px 4px;
@@ -791,7 +791,13 @@
     display: inline-block;
 }
 #fennec-trial-overlay .trial-order .trial-company-name {
-    font-size: calc(var(--sb-font-size) + 7px);
+    font-size: calc(var(--sb-font-size) + 10px);
+}
+#fennec-trial-overlay .trial-order .trial-tags .copilot-tag {
+    font-size: calc(var(--sb-font-size) + 5px);
+}
+#fennec-trial-overlay .trial-order .trial-btn-line {
+    margin-top: 4px;
 }
 #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
     background-color: rgba(46,204,113,0.99);
@@ -981,6 +987,7 @@
     font-size: calc(var(--sb-font-size) + 7px);
     padding: 6px 14px;
     margin-left: 8px;
+    opacity: 0.5;
 }
 
 #fennec-trial-overlay.trial-header-green { background-color: rgba(46,46,46,0.98); }

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -85,7 +85,7 @@
     border-radius: 12px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-line {
-    font-size: calc(var(--sb-font-size) + 4px);
+    font-size: calc(var(--sb-font-size) + 6px);
     background: rgba(255,255,255,0.9);
     color: #000;
     padding: 2px 4px;
@@ -93,7 +93,13 @@
     display: inline-block;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-company-name {
-    font-size: calc(var(--sb-font-size) + 7px);
+    font-size: calc(var(--sb-font-size) + 10px);
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order .trial-tags .copilot-tag {
+    font-size: calc(var(--sb-font-size) + 5px);
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order .trial-btn-line {
+    margin-top: 4px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
     background-color: rgba(46,204,113,0.99);
@@ -143,6 +149,7 @@
     font-size: calc(var(--sb-font-size) + 7px);
     padding: 6px 14px;
     margin-left: 8px;
+    opacity: 0.5;
 }
 .fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(255,255,255,0.98); }
 .fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(255,255,255,0.98); }


### PR DESCRIPTION
## Summary
- enlarge trial header text and reformat order info
- show order type, expedited flag and cost as tags
- move the floater action button to its own line and fade it out
- ensure single big button placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d85f8e4608326817fafd6d73c5844