### PR TITLE
Adjust trial floater header layout

### DIFF
--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -778,6 +778,8 @@
 #fennec-trial-overlay .trial-order {
     text-align: center;
     margin-bottom: 8px;
+    border-radius: 12px;
+    overflow: hidden;
 }
 #fennec-trial-overlay .trial-order .trial-col {
     border-radius: 12px;
@@ -788,7 +790,8 @@
     color: #000;
     padding: 2px 4px;
     border-radius: 4px;
-    display: inline-block;
+    display: block;
+    width: 100%;
 }
 #fennec-trial-overlay .trial-order .trial-company-name {
     font-size: calc(var(--sb-font-size) + 10px);

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -80,6 +80,8 @@
 .fennec-light-mode #fennec-trial-overlay .trial-order {
     text-align: center;
     margin-bottom: 8px;
+    border-radius: 12px;
+    overflow: hidden;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-col {
     border-radius: 12px;
@@ -90,7 +92,8 @@
     color: #000;
     padding: 2px 4px;
     border-radius: 4px;
-    display: inline-block;
+    display: block;
+    width: 100%;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-company-name {
     font-size: calc(var(--sb-font-size) + 10px);


### PR DESCRIPTION
## Summary
- round corners for trial floater header
- stack company info lines vertically in trial floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d8ca1b7dc832684f653e1af4967f6