### PR TITLE
Fix fraud XRAY completion handling

### DIFF
--- a/FENNEC/environments/db/db_email_search.js
+++ b/FENNEC/environments/db/db_email_search.js
@@ -15,6 +15,20 @@
             });
         }
 
+        function waitForResults(callback) {
+            const tbody = document.querySelector('.search_result tbody');
+            if (!tbody) { setTimeout(() => waitForResults(callback), 100); return; }
+            const rows = tbody.querySelectorAll('tr');
+            if (rows.length) { callback(); return; }
+            const obs = new MutationObserver(() => {
+                if (tbody.querySelector('tr')) {
+                    obs.disconnect();
+                    callback();
+                }
+            });
+            obs.observe(tbody, { childList: true });
+        }
+
         function run() {
             const input = document.querySelector('#search_field');
             if (input) {
@@ -23,13 +37,10 @@
             }
             const btn = document.querySelector('button[type="submit"],input[type="submit"]');
             if (btn) btn.click();
-            const gather = () => {
-                const rows = document.querySelectorAll('.search_result tbody tr');
-                if (!rows.length) { setTimeout(gather, 500); return; }
+            waitForResults(() => {
                 const orders = collectOrders();
                 chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
-            };
-            gather();
+            });
         }
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', run);

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -16,6 +16,13 @@
     let reviewMode = false;
     let devMode = false;
     let fraudXray = new URLSearchParams(location.search).get('fraud_xray') === '1';
+    if (fraudXray && localStorage.getItem('fraudXrayFinished') === '1') {
+        const params = new URLSearchParams(location.search);
+        params.delete('fraud_xray');
+        const newUrl = location.pathname + (params.toString() ? '?' + params.toString() : '');
+        history.replaceState(null, '', newUrl);
+        fraudXray = false;
+    }
     let subCheck = new URLSearchParams(location.search).get('fennec_sub_check') === '1';
     const currentId = (location.pathname.match(/(?:detail|storage\/incfile)\/(\d+)/) || [])[1];
     const xrayDoneId = localStorage.getItem('fraudXrayCompleted');

--- a/FENNEC/environments/db/db_order_search.js
+++ b/FENNEC/environments/db/db_order_search.js
@@ -17,6 +17,20 @@
             });
         }
 
+        function waitForResults(callback) {
+            const tbody = document.querySelector('.search_result tbody');
+            if (!tbody) { setTimeout(() => waitForResults(callback), 100); return; }
+            const rows = tbody.querySelectorAll('tr');
+            if (rows.length) { callback(); return; }
+            const obs = new MutationObserver(() => {
+                if (tbody.querySelector('tr')) {
+                    obs.disconnect();
+                    callback();
+                }
+            });
+            obs.observe(tbody, { childList: true });
+        }
+
         function run() {
             const input = document.querySelector('#search_field');
             if (input) {
@@ -25,13 +39,10 @@
             }
             const btn = document.getElementById('mainSearching') || document.querySelector('#mainSearching');
             if (btn) btn.click();
-            const gather = () => {
-                const rows = document.querySelectorAll('.search_result tbody tr');
-                if (!rows.length) { setTimeout(gather, 500); return; }
+            waitForResults(() => {
                 const orders = collectOrders();
                 chrome.runtime.sendMessage({ action: 'dbEmailSearchResults', orders });
-            };
-            gather();
+            });
         }
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', run);

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -73,6 +73,7 @@
         function runXray(orderId) {
             const dbUrl = `https://db.incfile.com/incfile/order/detail/${orderId}?fraud_xray=1`;
             sessionStorage.setItem('fennecShowTrialFloater', '1');
+            localStorage.removeItem('fraudXrayFinished');
             chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true, refocus: true });
         }
 
@@ -475,6 +476,7 @@
                 } else {
                     localStorage.setItem('fraudXrayCompleted', '1');
                 }
+                localStorage.setItem('fraudXrayFinished', '1');
                 chrome.runtime.sendMessage({ action: 'refocusTab' });
                 let overlay = document.getElementById('fennec-trial-overlay');
                 let title = document.getElementById('fennec-trial-title');


### PR DESCRIPTION
## Summary
- prevent XRAY flow from restarting after completion by tracking `fraudXrayFinished`
- restore the tracker as soon as search results load with improved waiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d93cd20a08326a1cab801635f4f92