### PR TITLE
Fix Fraud Review session cleanup

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2781,6 +2781,7 @@ function getLastHoldUser() {
             return;
         }
         const orderId = getBasicOrderInfo().orderId;
+        chrome.storage.local.set({ fraudReviewSession: orderId, sidebarFreezeId: orderId });
         const key = 'fennecLtvRefreshed_' + orderId;
         if (sessionStorage.getItem('fraudXrayPending')) {
             // Wait until the page reloads for accurate LTV

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -74,7 +74,17 @@
             const dbUrl = `https://db.incfile.com/incfile/order/detail/${orderId}?fraud_xray=1`;
             sessionStorage.setItem('fennecShowTrialFloater', '1');
             localStorage.removeItem('fraudXrayFinished');
-            chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true, refocus: true });
+            chrome.storage.local.set({
+                fraudReviewSession: orderId,
+                sidebarFreezeId: orderId,
+                sidebarDb: [],
+                sidebarOrderId: null,
+                sidebarOrderInfo: null,
+                adyenDnaInfo: null,
+                kountInfo: null
+            }, () => {
+                chrome.runtime.sendMessage({ action: 'openTab', url: dbUrl, active: true, refocus: true });
+            });
         }
 
         function addXrayIcon(el, orderId) {
@@ -529,6 +539,7 @@
                 if (close) close.addEventListener('click', () => {
                     overlay.remove();
                     title.remove();
+                    endFraudSession();
                     chrome.runtime.sendMessage({ action: 'refocusTab' });
                 });
                 const subBtn = overlay.querySelector('#sub-detection-btn');
@@ -596,7 +607,7 @@
                     clickDbAction(selector);
                     overlay.remove();
                     title.remove();
-                    clearSidebar();
+                    endFraudSession();
                     showTrialSuccess();
                     chrome.runtime.sendMessage({ action: 'refocusTab' });
                 }
@@ -979,6 +990,18 @@
             if (fraud) fraud.innerHTML = '';
             if (issue) { const content = issue.querySelector('#issue-summary-content'); const label = issue.querySelector('#issue-status-label'); if (content) content.innerHTML = 'No issue data yet.'; if (label) { label.textContent = ''; label.className = 'issue-status-label'; } issue.style.display = 'none'; }
             insertFraudSummary();
+        }
+
+        function endFraudSession() {
+            clearSidebar();
+            chrome.storage.local.set({
+                fraudReviewSession: null,
+                kountInfo: null
+            });
+            localStorage.removeItem('fraudXrayCompleted');
+            localStorage.removeItem('fraudXrayFinished');
+            sessionStorage.removeItem('fennecShowTrialFloater');
+            showInitialStatus();
         }
 
         function showInitialStatus() {


### PR DESCRIPTION
## Summary
- start a Fraud Review session when running XRAY
- clear the session and sidebar when closing the Trial overlay or taking action
- clean up local storage when the DB page starts the XRAY flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686da68a9f288326b10e5c5b555eacf2