### PR TITLE
Add Kount linked order info to trial floater

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Trial header fills the width and changes color (green, purple or red) based on the main action. ADYEN info reliably appears after XRAY.
 - Fraud Review shows a floating **TRIAL SUMMARY** with CVV, AVS, DB match and Kount checks after returning from XRAY.
 - TRIAL SUMMARY overlay now waits for XRAY data and retries briefly if the information isn't ready.
+- TRIAL floater displays Kount linked order counts (email, IP, customer ID, payment, billing/shipping address and device).
 - Family Tree detects duplicate orders in review, processing or hold and adds a ❌ icon to cancel and refund them.
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -872,6 +872,27 @@
                     kountLines.push(`<div class="trial-line">VIP DECLINES: ${count} <span class="${count === 0 ? 'db-adyen-check' : 'db-adyen-cross'}">${count === 0 ? '✔' : '✖'}</span></div>`);
                 }
                 if (kount.ekata && kount.ekata.addressToName) kountLines.push(`<div class="trial-line">Address Name: ${escapeHtml(kount.ekata.addressToName)}</div>`);
+
+                if (kount.linked) {
+                    const map = [
+                        ['email', 'Email'],
+                        ['ip', 'IP Address'],
+                        ['custId', 'Cust. ID'],
+                        ['payment', 'Payment'],
+                        ['billAddr', 'Bill Addr'],
+                        ['shipAddr', 'Ship Addr'],
+                        ['deviceId', 'Device ID']
+                    ];
+                    const total = map.reduce((sum, [k]) => sum + (parseInt(kount.linked[k] || 0, 10)), 0);
+                    if (total === 0) {
+                        kountLines.push(`<div class="trial-line">NO LINKED ORDERS <span class="db-adyen-check">✔</span></div>`);
+                    } else {
+                        map.forEach(([k, label]) => {
+                            const n = parseInt(kount.linked[k] || 0, 10);
+                            if (n > 0) kountLines.push(`<div class="trial-line">${label}: ${n}</div>`);
+                        });
+                    }
+                }
             }
 
             const actions = `

--- a/FENNEC/environments/kount/kount_launcher.js
+++ b/FENNEC/environments/kount/kount_launcher.js
@@ -41,7 +41,26 @@
                             })
                             .filter(Boolean);
 
-                        saveData({ emailAge, deviceLocation, ip, declines });
+                        const linked = {};
+                        document.querySelectorAll('#link-analysis tbody tr').forEach(row => {
+                            const th = row.querySelector('th');
+                            const countEl = row.querySelector('.count');
+                            if (!th || !countEl) return;
+                            const label = th.textContent.replace(/:\s*$/, '').trim();
+                            const num = parseInt(countEl.textContent.replace(/[^0-9]/g, ''), 10) || 0;
+                            switch (label) {
+                                case 'Email': linked.email = num; break;
+                                case 'IP Address': linked.ip = num; break;
+                                case 'Cust. ID': linked.custId = num; break;
+                                case 'Payment': linked.payment = num; break;
+                                case 'Bill Addr': linked.billAddr = num; break;
+                                case 'Ship Addr': linked.shipAddr = num; break;
+                                case 'Device ID': linked.deviceId = num; break;
+                                default: break;
+                            }
+                        });
+
+                        saveData({ emailAge, deviceLocation, ip, declines, linked });
 
                         const ekataLink = document.querySelector('a[href*="/workflow/ekata"]');
                         if (ekataLink) {


### PR DESCRIPTION
## Summary
- grab linked order counts from Kount link analysis gadget
- display counts in Trial floater under the Kount column
- document feature in CHANGELOG

## Testing
- `npm test --prefix FENNEC`

------
https://chatgpt.com/codex/tasks/task_e_686e87ab855c8326aabf4618e9c38873