### PR TITLE
Add drag & drop uploads in Gmail issue box

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -8,6 +8,7 @@
 - TRIAL SUMMARY overlay now waits for XRAY data and retries briefly if the information isn't ready.
 - TRIAL floater displays Kount linked order counts (email, IP, customer ID, payment, billing/shipping address and device).
 - Family Tree detects duplicate orders in review, processing or hold and adds a ❌ icon to cancel and refund them.
+- Issue comment box in Gmail now supports drag-and-drop uploads and no longer shows a file chooser.
 - Diagnose overlay now supports Reinstatement orders and detects amendments or reinstatements in review.
 - Replaced `form.submit()` fallback with a submit event to mimic real clicks.
 - XRAY flow opens the DB order search page with the client's email instead of a Gmail search tab.


### PR DESCRIPTION
## Summary
- support storing dropped files via `droppedFile`
- change Gmail issue comment box to accept drag and drop
- remove the old file input
- document the new behavior in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9709a5f083269b47e371713b6c65