### PR TITLE
Improve update floater UI

### DIFF
--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2323,28 +2323,29 @@
     function applyUpdateFields(updates) {
         if (!updates) return;
         const selectors = {
-            companyName: 'input[name="companyName"]',
-            companyPrincipal: 'input[name="company_principal_address"]',
-            companyMailing: 'input[name="company_mailing_address"]',
-            purpose: 'textarea[name="purpose"]',
-            agentName: 'input[name="agent_name"]',
-            agentAddress: 'input[name="agent_address"]',
-            memberName: 'input[name="member_name"]',
-            memberAddress: 'input[name="member_address"]',
-            directors: 'textarea[name="directors"]',
-            shareholders: 'textarea[name="shareholders"]',
-            officers: 'textarea[name="officers"]'
+            companyName: ['button[onclick*="modalEditCompInfo"]', '#modalEditCompInfo', '#compName1', 'button[onclick*="update-comp-info"]']
         };
-        Object.keys(updates).forEach(k => {
-            const sel = selectors[k];
-            const el = sel && document.querySelector(sel);
-            if (el) {
-                el.value = updates[k];
-                el.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-        });
-        const saveBtn = document.querySelector('#btnUpdateOrder');
-        if (saveBtn) saveBtn.click();
+        const queue = Object.keys(updates);
+        function next() {
+            if (!queue.length) return;
+            const key = queue.shift();
+            const cfg = selectors[key];
+            if (!cfg) { next(); return; }
+            const [btnSel, modalSel, inputSel, saveSel] = cfg;
+            const btn = document.querySelector(btnSel);
+            if (btn) btn.click();
+            setTimeout(() => {
+                const input = document.querySelector(modalSel + ' ' + inputSel);
+                if (input) {
+                    input.value = updates[key];
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+                const save = document.querySelector(modalSel + ' ' + saveSel);
+                if (save) save.click();
+                setTimeout(next, 600);
+            }, 400);
+        }
+        next();
     }
 
     function processUpdateRequest(data) {

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1673,38 +1673,64 @@
             container.className = 'update-fields';
             overlay.appendChild(container);
 
-            const fields = [
-                ['companyName', 'COMPANY NAME'],
-                ['companyPrincipal', 'COMPANY PRINCIPAL ADDRESS'],
-                ['companyMailing', 'COMPANY MAILING ADDRESS'],
-                ['purpose', 'PURPOSE'],
-                ['agentName', 'AGENT NAME'],
-                ['agentAddress', 'AGENT ADDRESS'],
-                ['memberName', 'MEMBER NAME'],
-                ['memberAddress', 'MEMBER ADDRESS'],
-                ['directors', 'DIRECTORS (NAME AND ADDRESS)'],
-                ['shareholders', 'SHAREHOLDERS (NAME AND ADDRESS)'],
-                ['officers', 'OFFICERS (NAME AND ADDRESS)']
+            const sections = [
+                ['COMPANY', [
+                    ['companyName', 'COMPANY NAME', storedOrderInfo ? storedOrderInfo.companyName : ''],
+                    ['companyPrincipal', 'COMPANY PRINCIPAL ADDRESS', storedOrderInfo ? (storedOrderInfo.companyAddress || '') : ''],
+                    ['companyMailing', 'COMPANY MAILING ADDRESS', storedOrderInfo ? (storedOrderInfo.companyMailing || '') : ''],
+                    ['purpose', 'PURPOSE', storedOrderInfo ? (storedOrderInfo.purpose || '') : '']
+                ]],
+                ['RA', [
+                    ['agentName', 'AGENT NAME', storedOrderInfo && storedOrderInfo.registeredAgent ? storedOrderInfo.registeredAgent.name : ''],
+                    ['agentAddress', 'AGENT ADDRESS', storedOrderInfo && storedOrderInfo.registeredAgent ? storedOrderInfo.registeredAgent.address : '']
+                ]],
+                ['MEMBERS/DIRECTORS', [
+                    ['memberName', 'MEMBER NAME', ''],
+                    ['memberAddress', 'MEMBER ADDRESS', '']
+                ]],
+                ['OFFICERS', [
+                    ['officers', 'OFFICERS (NAME AND ADDRESS)', '']
+                ]],
+                ['SHAREHOLDERS', [
+                    ['shareholders', 'SHAREHOLDERS (NAME AND ADDRESS)', '']
+                ]]
             ];
 
-            fields.forEach(([key, label]) => {
-                const row = document.createElement('div');
-                const cb = document.createElement('input');
-                cb.type = 'checkbox';
-                cb.dataset.field = key;
-                const lbl = document.createElement('label');
-                lbl.textContent = ' ' + label;
-                lbl.prepend(cb);
-                row.appendChild(lbl);
-                const input = document.createElement('textarea');
-                input.dataset.field = key;
-                input.style.display = 'none';
-                input.className = 'update-input';
-                cb.addEventListener('change', () => {
-                    input.style.display = cb.checked ? 'block' : 'none';
+            const fields = [];
+            sections.forEach(([title, items]) => {
+                const sec = document.createElement('div');
+                sec.className = 'update-section';
+                const h = document.createElement('div');
+                h.className = 'update-section-title';
+                h.textContent = title;
+                sec.appendChild(h);
+                items.forEach(([key, label, value]) => {
+                    const row = document.createElement('div');
+                    row.className = 'update-row';
+                    const cb = document.createElement('input');
+                    cb.type = 'checkbox';
+                    cb.dataset.field = key;
+                    const lbl = document.createElement('label');
+                    lbl.textContent = ' ' + label;
+                    lbl.prepend(cb);
+                    const span = document.createElement('span');
+                    span.className = 'update-current';
+                    if (value) span.textContent = ' (' + value + ')';
+                    lbl.appendChild(span);
+                    row.appendChild(lbl);
+                    const input = document.createElement('textarea');
+                    input.dataset.field = key;
+                    input.style.display = 'none';
+                    input.className = 'update-input';
+                    input.value = value || '';
+                    cb.addEventListener('change', () => {
+                        input.style.display = cb.checked ? 'block' : 'none';
+                    });
+                    row.appendChild(input);
+                    sec.appendChild(row);
+                    fields.push([key, input, cb]);
                 });
-                row.appendChild(input);
-                container.appendChild(row);
+                container.appendChild(sec);
             });
 
             const submit = document.createElement('button');

--- a/FENNEC/styles/sidebar.css
+++ b/FENNEC/styles/sidebar.css
@@ -914,6 +914,10 @@
     margin: 4px 0 8px;
     height: 40px;
 }
+.update-section-title {
+    font-weight: bold;
+    margin: 6px 0 4px;
+}
 
 #fennec-kb-backdrop {
     position: fixed;

--- a/FENNEC/styles/sidebar_light.css
+++ b/FENNEC/styles/sidebar_light.css
@@ -342,6 +342,11 @@
     color: #000;
     border: 1px solid #777;
 }
+.fennec-light-mode .update-section-title {
+    font-weight: bold;
+    margin: 6px 0 4px;
+    color: #000;
+}
 .fennec-light-mode #fennec-trial-overlay .trial-company-name {
     font-size: calc(var(--sb-font-size) + 12px);
     font-weight: bold;


### PR DESCRIPTION
## Summary
- organize the Update overlay into sections and show current values
- style section titles for light/dark themes
- start using DB modal forms to edit company name

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9e8cb9cc83268ca38580546fa99a