### PR TITLE
Implement Gmail session isolation

### DIFF
--- a/FENNEC/CHANGELOG.md
+++ b/FENNEC/CHANGELOG.md
@@ -157,3 +157,4 @@
 - The DB search page now opens only after DNA extraction so the order history is retrieved at the end of XRAY.
 - Comment & resolve now runs in the background without changing focus.
 - New UPDATE floater collects order edits and opens the DB tab silently.
+- Gmail Review Mode now isolates each tab. Opening a new Gmail session resets the sidebar to the initial view instead of reusing old data.

--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -7,6 +7,13 @@
             return;
         }
 
+        chrome.storage.local.get({ fennecActiveSession: null }, ({ fennecActiveSession }) => {
+            if (fennecActiveSession) {
+                sessionStorage.setItem('fennecSessionId', fennecActiveSession);
+            }
+            getFennecSessionId();
+        });
+
         try {
             const params = new URLSearchParams(window.location.search);
             const orderParam = params.get('fennec_order');
@@ -70,7 +77,7 @@
             function saveData(part) {
                 chrome.storage.local.get({ adyenDnaInfo: {} }, ({ adyenDnaInfo }) => {
                     const updated = Object.assign({}, adyenDnaInfo, part);
-                    chrome.storage.local.set({ adyenDnaInfo: updated });
+                    sessionSet({ adyenDnaInfo: updated });
                     console.log('[FENNEC Adyen] Data saved', part);
                 });
             }
@@ -384,7 +391,7 @@
             }
 
             function clearSidebar() {
-                chrome.storage.local.set({
+                sessionSet({
                     sidebarDb: [],
                     sidebarOrderId: null,
                     sidebarOrderInfo: null,
@@ -585,6 +592,10 @@
             }
 
             chrome.storage.onChanged.addListener((changes, area) => {
+                if (area === 'local' && changes.sidebarSessionId &&
+                    changes.sidebarSessionId.newValue !== getFennecSessionId()) {
+                    return;
+                }
                 if (area === 'local' && changes.sidebarDb) loadDbSummary();
                 if (area === 'local' && changes.adyenDnaInfo) loadDnaSummary();
                 if (area === 'local' && changes.sidebarSnapshot && changes.sidebarSnapshot.newValue) {


### PR DESCRIPTION
## Summary
- manage per-session IDs and utilities
- honor session data in Gmail, DB and Adyen scripts
- isolate sidebar state when opening new Gmail tabs
- document session isolation in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eaee664788326b620d60613d01bc2