### PR TITLE
Add issue summary for Fraud Review

### DIFF
--- a/FENNEC/environments/adyen/adyen_launcher.js
+++ b/FENNEC/environments/adyen/adyen_launcher.js
@@ -333,6 +333,11 @@
 
             function formatIssueText(text) {
                 if (!text) return '';
+                const norm = text.toLowerCase().replace(/\s+/g, ' ').trim();
+                if (norm.includes('a clear photo of the card used to pay for the order') &&
+                    norm.includes('selfie holding your id')) {
+                    return 'ID CONFIRMATION ISSUE';
+                }
                 let formatted = text.replace(/\s*(\d+\s*[).])/g, (m, g) => '\n' + g + ' ');
                 return formatted.replace(/^\n/, '').trim();
             }

--- a/FENNEC/environments/db/db_launcher.js
+++ b/FENNEC/environments/db/db_launcher.js
@@ -2062,6 +2062,11 @@
 
     function formatIssueText(text) {
         if (!text) return '';
+        const norm = text.toLowerCase().replace(/\s+/g, ' ').trim();
+        if (norm.includes('a clear photo of the card used to pay for the order') &&
+            norm.includes('selfie holding your id')) {
+            return 'ID CONFIRMATION ISSUE';
+        }
         let formatted = text.replace(/\s*(\d+\s*[).])/g, (m, g) => '\n' + g + ' ');
         return formatted.replace(/^\n/, '').trim();
     }

--- a/FENNEC/environments/db/tracker_fraud.js
+++ b/FENNEC/environments/db/tracker_fraud.js
@@ -45,6 +45,10 @@
                         <div id="kount-summary" style="margin-top:10px"></div>
                     </div>
                     <div id="fraud-summary-section"></div>
+                    <div class="issue-summary-box" id="issue-summary-box" style="display:none; margin-top:10px;">
+                        <strong>ISSUE <span id="issue-status-label" class="issue-status-label"></span></strong><br>
+                        <div id="issue-summary-content" style="color:#ccc; font-size:13px; white-space:pre-line;">No issue data yet.</div>
+                    </div>
                     <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                     <div id="review-mode-label" class="review-mode-label" style="margin-top:4px; text-align:center; font-size:11px;">REVIEW MODE</div>
                 </div>`;
@@ -940,6 +944,11 @@
 
         function formatIssueText(text) {
             if (!text) return '';
+            const norm = text.toLowerCase().replace(/\s+/g, ' ').trim();
+            if (norm.includes('a clear photo of the card used to pay for the order') &&
+                norm.includes('selfie holding your id')) {
+                return 'ID CONFIRMATION ISSUE';
+            }
             let formatted = text.replace(/\s*(\d+\s*[).])/g, (m,g)=>'\n'+g+' ');
             return formatted.replace(/^\n/, '').trim();
         }

--- a/FENNEC/environments/gmail/gmail_launcher.js
+++ b/FENNEC/environments/gmail/gmail_launcher.js
@@ -1090,6 +1090,11 @@
 
         function formatIssueText(text) {
             if (!text) return '';
+            const norm = text.toLowerCase().replace(/\s+/g, ' ').trim();
+            if (norm.includes('a clear photo of the card used to pay for the order') &&
+                norm.includes('selfie holding your id')) {
+                return 'ID CONFIRMATION ISSUE';
+            }
             let formatted = text.replace(/\s*(\d+\s*[).])/g, (m, g) => '\n' + g + ' ');
             return formatted.replace(/^\n/, '').trim();
         }


### PR DESCRIPTION
## Summary
- add issue summary box to Fraud Review sidebar
- detect ID Confirmation issue text across sidebars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ebc8d5d1c8326938a18258a295bb2