### PR TITLE
Add reset extension feature in popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Start of new changelog.
+- Added Reset Extension button in the popup to clear storage and reload.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ GENERAL FEATURES:
 3. Enable **Developer mode** (toggle in the top right).
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
-5. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode. You can also toggle Review Mode directly from the extension popup.
+5. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode. You can also toggle Review Mode directly from the extension popup. The popup now includes a **Reset Extension** button to clear saved settings and reload.
 
 
 ## Local Mistral integration

--- a/popup.html
+++ b/popup.html
@@ -18,6 +18,7 @@
     <label for="review-toggle">Review Mode</label>
   </div>
   <button id="options-btn" style="margin-top:8px; width:100%;">Go to Options</button>
+  <button id="reset-btn" style="margin-top:8px; width:100%;">Reset Extension</button>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,7 @@
 const toggle = document.getElementById("extension-toggle");
 const optionsBtn = document.getElementById("options-btn");
 const reviewToggle = document.getElementById("review-toggle");
+const resetBtn = document.getElementById("reset-btn");
 let lastReviewMode = false;
 
 function loadState() {
@@ -42,9 +43,19 @@ function saveState() {
     });
 }
 
+function resetExtension() {
+    if (!confirm("Reset all FENNEC data and reload?")) return;
+    chrome.storage.local.clear(() => {
+        chrome.storage.sync.clear(() => {
+            chrome.runtime.reload();
+        });
+    });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     loadState();
     toggle.addEventListener("change", saveState);
     reviewToggle.addEventListener("change", saveState);
     optionsBtn.addEventListener("click", () => chrome.runtime.openOptionsPage());
+    resetBtn.addEventListener("click", resetExtension);
 });


### PR DESCRIPTION
## Summary
- add Reset Extension button to `popup.html`
- implement storage clearing and reload in `popup.js`
- document the new button in README
- record the feature in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef169f4888326b56e8722e9e9d399