### PR TITLE
Fix XRAY fallback in Gmail Review Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - Start of new changelog.
+- Fixed GM SB XRAY button using stored order ID when none found in email.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1378,8 +1378,11 @@
 
             const urls = [gmailSearchUrl];
 
-            if (context.orderNumber) {
-                let dbOrderUrl = `https://db.incfile.com/incfile/order/detail/${context.orderNumber}`;
+            const orderIdFallback = storedOrderInfo && storedOrderInfo.orderId;
+            const orderId = context.orderNumber || (xray ? orderIdFallback : null);
+
+            if (orderId) {
+                let dbOrderUrl = `https://db.incfile.com/incfile/order/detail/${orderId}`;
                 if (xray) dbOrderUrl += '?fraud_xray=1';
                 urls.push(dbOrderUrl);
             } else {
@@ -1396,10 +1399,10 @@
                     adyenDnaInfo: null,
                     kountInfo: null
                 });
-            } else if (context.orderNumber) {
+            } else if (orderId) {
                 Object.assign(data, {
-                    fraudReviewSession: context.orderNumber,
-                    sidebarFreezeId: context.orderNumber,
+                    fraudReviewSession: orderId,
+                    sidebarFreezeId: orderId,
                     sidebarDb: [],
                     sidebarOrderId: null,
                     sidebarOrderInfo: null,
@@ -1412,8 +1415,8 @@
             sessionSet(data, () => {
                 chrome.runtime.sendMessage({ action: "replaceTabs", urls });
             });
-            if (context.orderNumber) {
-                checkLastIssue(context.orderNumber);
+            if (orderId) {
+                checkLastIssue(orderId);
             }
         }
 


### PR DESCRIPTION
## Summary
- update Gmail XRAY flow to use stored order ID when none found in email
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef1f049cc8326b47932b6b150593a