### PR TITLE
Add icons in Review Mode headers

### DIFF
--- a/FRAUD_REVIEW_EXAMPLE.html
+++ b/FRAUD_REVIEW_EXAMPLE.html
@@ -8072,10 +8072,12 @@
 
 <div id="copilot-sidebar" style="--sb-bg: #212121; --sb-box-bg: #2e2e2e; --sb-font-size: 13px; --sb-font-family: &#39;Inter&#39;, sans-serif;">
                 <div class="copilot-header">
+                    <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                     <div class="copilot-title">
                         <img src="chrome-extension://igmakglgfdaggjhnibjgboiciamchagm/fennec_icon.png" class="copilot-icon" alt="FENNEC (BETA)">
                         <span>FENNEC (BETA)</span>
                     </div>
+                    <button id="copilot-clear-tabs">🗑</button>
                     <button id="copilot-close">✕</button>
                 </div>
                 <div class="copilot-body" id="copilot-body-content">

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -413,10 +413,12 @@
                 sidebar.id = 'copilot-sidebar';
                 sidebar.innerHTML = `
                     <div class="copilot-header">
+                        <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                         <div class="copilot-title">
                             <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (BETA)" />
                             <span>FENNEC (BETA)</span>
                         </div>
+                        <button id="copilot-clear-tabs">🗑</button>
                         <button id="copilot-close">✕</button>
                     </div>
                     <div class="copilot-body">
@@ -444,6 +446,12 @@
                     closeBtn.onclick = () => {
                         sidebar.remove();
                         document.body.style.marginRight = '';
+                    };
+                }
+                const clearTabsBtn = sidebar.querySelector('#copilot-clear-tabs');
+                if (clearTabsBtn) {
+                    clearTabsBtn.onclick = () => {
+                        chrome.runtime.sendMessage({ action: 'closeOtherTabs' });
                     };
                 }
                 const clearSb = sidebar.querySelector('#copilot-clear');

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -30,6 +30,7 @@
             sidebar.id = 'copilot-sidebar';
             sidebar.innerHTML = `
                 <div class="copilot-header">
+                    <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                     <div class="copilot-title">
                         <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (BETA)" />
                         <span>FENNEC (BETA)</span>


### PR DESCRIPTION
## Summary
- include hamburger and trash icons in Review Mode headers
- wire up trash icon to close tabs in Adyen environment
- update Review Mode example page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ef2d808bc83269b9e6a803cbc5269