### PR TITLE
Refactor extension scripts to use ES modules

### DIFF
--- a/core/BaseLauncher.js
+++ b/core/BaseLauncher.js
@@ -1,0 +1,27 @@
+import Sidebar from './sidebar.js';
+
+export default class BaseLauncher {
+    constructor() {
+        this.sidebar = new Sidebar();
+    }
+
+    showFloatingIcon(callback) {
+        if (document.getElementById('fennec-floating-icon')) return;
+        const icon = document.createElement('img');
+        icon.id = 'fennec-floating-icon';
+        icon.src = chrome.runtime.getURL('fennec_icon.png');
+        icon.alt = 'FENNEC';
+        icon.addEventListener('click', () => {
+            icon.remove();
+            sessionStorage.removeItem('fennecSidebarClosed');
+            if (typeof callback === 'function') callback();
+        });
+        document.body.appendChild(icon);
+    }
+
+    ensureFloatingIcon(callback) {
+        if (!document.getElementById('fennec-floating-icon')) {
+            this.showFloatingIcon(callback);
+        }
+    }
+}

--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -1,13 +1,20 @@
 // Background worker handling tab management and other extension messages
 // Use a declarative rule to strip the Origin header from local Mistral API
 // requests so Ollama accepts them without CORS errors.
-function registerMistralRule() {
-    chrome.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: [1],
-        addRules: [{
-            id: 1,
-            priority: 1,
-            action: {
+
+export default class BackgroundService {
+    constructor() {
+        this.registerMistralRule();
+        this.registerListeners();
+    }
+
+    registerMistralRule() {
+        chrome.declarativeNetRequest.updateDynamicRules({
+            removeRuleIds: [1],
+            addRules: [{
+                id: 1,
+                priority: 1,
+                action: {
                 type: "modifyHeaders",
                 requestHeaders: [{ header: "origin", operation: "remove" }]
             },
@@ -16,12 +23,11 @@ function registerMistralRule() {
                 resourceTypes: ["xmlhttprequest"]
             }
         }]
-    });
-}
+        });
+    }
 
-registerMistralRule();
-
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    registerListeners() {
+        chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "openTab" && message.url) {
         console.log("[Copilot] Forzando apertura de una pestaña:", message.url);
         const opts = { url: message.url, active: Boolean(message.active) };
@@ -758,3 +764,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return;
     }
 });
+    }
+}
+
+new BackgroundService();

--- a/core/sidebar.js
+++ b/core/sidebar.js
@@ -1,0 +1,25 @@
+export default class Sidebar {
+    constructor(id = 'copilot-sidebar') {
+        this.id = id;
+        this.element = null;
+    }
+
+    create() {
+        this.element = document.createElement('div');
+        this.element.id = this.id;
+        return this.element;
+    }
+
+    attach(parent = document.body) {
+        if (!this.element) {
+            this.create();
+        }
+        parent.appendChild(this.element);
+    }
+
+    remove() {
+        if (this.element && this.element.parentNode) {
+            this.element.parentNode.removeChild(this.element);
+        }
+    }
+}

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -1,6 +1,15 @@
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
 // Auto-navigates to the DNA page and collects payment/transaction info when an
 // order number is provided via ?fennec_order= in the URL or session storage.
-(function() {
+
+export default class AdyenLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function() {
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping Adyen launcher.');
@@ -305,7 +314,7 @@
                         const html = buildDnaHtml(adyenDnaInfo);
                         container.innerHTML = html || '';
                         attachCommonListeners(container);
-                        if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
+                        if (isDnaPage) storeSidebarSnapshot(launcher.sidebar.element);
                     });
                 });
             }
@@ -318,7 +327,7 @@
                         container.innerHTML = sidebarDb.join('');
                         container.style.display = 'block';
                         attachCommonListeners(container);
-                        if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
+                        if (isDnaPage) storeSidebarSnapshot(launcher.sidebar.element);
                         const qbox = container.querySelector('#quick-summary');
                         if (qbox) {
                             qbox.classList.remove('quick-summary-collapsed');
@@ -358,7 +367,7 @@
                     label.textContent = '';
                     label.className = 'issue-status-label';
                 }
-                if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
+                if (isDnaPage) storeSidebarSnapshot(launcher.sidebar.element);
             }
 
             function checkLastIssue(orderId) {
@@ -409,7 +418,7 @@
 
             function injectSidebar() {
                 if (document.getElementById('copilot-sidebar')) return;
-                const sidebar = document.createElement('div');
+                const sidebar = launcher.sidebar.create();
                 sidebar.id = 'copilot-sidebar';
                 sidebar.innerHTML = `
                     <div class="copilot-header">
@@ -432,7 +441,7 @@
                         </div>
                         <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                     </div>`;
-                document.body.appendChild(sidebar);
+                launcher.sidebar.attach(document.body);
                 chrome.storage.sync.get({
                     sidebarFontSize: 13,
                     sidebarFont: "'Inter', sans-serif",
@@ -444,7 +453,7 @@
                 const closeBtn = sidebar.querySelector('#copilot-close');
                 if (closeBtn) {
                     closeBtn.onclick = () => {
-                        sidebar.remove();
+                        launcher.sidebar.remove();
                         document.body.style.marginRight = '';
                     };
                 }
@@ -624,3 +633,7 @@
         }
     });
 })();
+    }
+}
+
+new AdyenLauncher();

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1,5 +1,14 @@
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
 // Injects the FENNEC sidebar into DB pages.
-(function main() {
+
+export default class DbLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function main() {
     // Clear the closed flag on reloads so the sidebar reappears
     window.addEventListener('beforeunload', () => {
         sessionStorage.removeItem("fennecSidebarClosed");
@@ -481,7 +490,7 @@
 
                 (function injectSidebar() {
                     if (document.getElementById('copilot-sidebar')) return;
-                    const sidebar = document.createElement('div');
+                    const sidebar = launcher.sidebar.create();
                     sidebar.id = 'copilot-sidebar';
                     sidebar.innerHTML = `
                         <div class="copilot-header">
@@ -517,7 +526,7 @@
                             <div id="review-mode-label" class="review-mode-label" style="display:none; margin-top:4px; text-align:center; font-size:11px;">REVIEW MODE</div>
                         </div>
                     `;
-                    document.body.appendChild(sidebar);
+                    launcher.sidebar.attach(document.body);
                     chrome.storage.sync.get({
                         sidebarFontSize: 13,
                         sidebarFont: "'Inter', sans-serif",
@@ -530,7 +539,7 @@
                     const closeBtn = sidebar.querySelector('#copilot-close');
                     if (closeBtn) {
                         closeBtn.onclick = () => {
-                            sidebar.remove();
+                            launcher.sidebar.remove();
                             document.body.style.marginRight = '';
                             const style = document.getElementById('copilot-db-padding');
                             if (style) style.remove();
@@ -2983,3 +2992,7 @@ window.addEventListener('focus', () => {
     loadKountSummary();
 });
 })();
+    }
+}
+
+new DbLauncher();

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1,6 +1,15 @@
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
 // Injects the FENNEC sidebar into Gmail pages.
 // Pads main panels and the attachment viewer so content stays visible.
-(function persistentSidebar() {
+
+export default class GmailLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function persistentSidebar() {
     // Clear the closed flag on full reloads so the sidebar returns
     window.addEventListener('beforeunload', () => {
         sessionStorage.removeItem("fennecSidebarClosed");
@@ -1424,7 +1433,7 @@
         function injectSidebar(mainPanels) {
             if (document.getElementById('copilot-sidebar')) return;
 
-            const sidebar = document.createElement('div');
+            const sidebar = launcher.sidebar.create();
             sidebar.id = 'copilot-sidebar';
             sidebar.innerHTML = `
                 <div class="copilot-header">
@@ -1462,7 +1471,7 @@
                     <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                 </div>
             `;
-            document.body.appendChild(sidebar);
+            launcher.sidebar.attach(document.body);
             chrome.storage.sync.get({
                 sidebarFontSize: 13,
                 sidebarFont: "'Inter', sans-serif",
@@ -1483,7 +1492,7 @@
 
             // Botón de cierre
             document.getElementById('copilot-close').onclick = () => {
-                sidebar.remove();
+                launcher.sidebar.remove();
                 // Limpiar el margin aplicado a los paneles
                 mainPanels.forEach(el => el.style.marginRight = '');
                 sessionStorage.setItem("fennecSidebarClosed", "true");
@@ -1878,3 +1887,7 @@
     });
     });
 })();
+    }
+}
+
+new GmailLauncher();

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -1,4 +1,12 @@
-(function() {
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
+export default class KountLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function() {
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) return;
         try {
@@ -112,3 +120,7 @@
         }
     });
 })();
+    }
+}
+
+new KountLauncher();

--- a/environments/txsos/tx_sos_launcher.js
+++ b/environments/txsos/tx_sos_launcher.js
@@ -1,5 +1,14 @@
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
 // Autofills the Texas SOS login and payment pages when launched from the DB SB FILE button.
-(function() {
+
+export default class TxsosLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function() {
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log("[FENNEC] Extension disabled, skipping TX SOS launcher.");
@@ -146,3 +155,7 @@
         });
     });
 })();
+    }
+}
+
+new TxsosLauncher();

--- a/environments/usps/usps_launcher.js
+++ b/environments/usps/usps_launcher.js
@@ -1,5 +1,14 @@
+import BaseLauncher from '../../core/BaseLauncher.js';
+import Sidebar from '../../core/sidebar.js';
+
 // Injects the FENNEC sidebar into USPS pages.
-(function() {
+
+export default class UspsLauncher extends BaseLauncher {
+    constructor() {
+        super();
+        this.sidebar = new Sidebar();
+        const launcher = this;
+        (function() {
     chrome.runtime.onMessage.addListener((msg) => {
         if (msg.action === 'fennecToggle') {
             window.location.reload();
@@ -100,3 +109,7 @@
     }
     });
 })();
+    }
+}
+
+new UspsLauncher();

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
       "css": [
         "styles/sidebar.css",
         "styles/sidebar_light.css"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -50,7 +51,8 @@
       "css": [
         "styles/sidebar.css",
         "styles/sidebar_light.css"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -64,7 +66,8 @@
       "css": [
         "styles/sidebar.css",
         "styles/sidebar_light.css"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -74,7 +77,8 @@
       "js": [
         "core/utils.js",
         "environments/db/db_email_search.js"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -84,7 +88,8 @@
       "js": [
         "core/utils.js",
         "environments/db/db_order_search.js"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -92,7 +97,8 @@
       ],
       "js": [
         "environments/usps/usps_launcher.js"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -106,7 +112,8 @@
       "css": [
         "styles/sidebar.css",
         "styles/sidebar_light.css"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -120,7 +127,8 @@
       "css": [
         "styles/sidebar.css",
         "styles/sidebar_light.css"
-      ]
+      ],
+      "type": "module"
     },
     {
       "matches": [
@@ -130,7 +138,8 @@
       "js": [
         "core/utils.js",
         "environments/kount/kount_launcher.js"
-      ]
+      ],
+      "type": "module"
     }
   ],
   "web_accessible_resources": [


### PR DESCRIPTION
## Summary
- add `BaseLauncher` and `Sidebar` classes
- convert background script to `BackgroundService`
- make launchers extend `BaseLauncher`
- enable ES module type for all content scripts in the manifest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687042d01c5c832682cc271df300ed82