### PR TITLE
Fix diagnose overlay background color

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -620,7 +620,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background: var(--sb-box-bg);
+    background: var(--sb-box-bg, #2e2e2e);
     color: #f1f1f1;
     border: 1px solid gray;
     border-radius: 8px;
@@ -652,7 +652,7 @@
     margin: 8px;
     padding: 8px;
     border-radius: 8px;
-    background: var(--sb-box-bg);
+    background: var(--sb-box-bg, #2e2e2e);
     color: #f1f1f1;
     text-align: center;
 }
@@ -684,7 +684,7 @@
 }
 
 #fennec-diagnose-overlay .diag-issue {
-    background: var(--sb-box-bg);
+    background: var(--sb-box-bg, #2e2e2e);
     border-radius: 6px;
     padding: 6px;
     margin-top: 6px;


### PR DESCRIPTION
## Summary
- ensure diagnose floater uses default FENNEC background color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687122afbc508326a7eb8ee517fdae44