### PR TITLE
Fix Gmail sidebar issue box after XRAY

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1651,6 +1651,20 @@
             }
         });
 
+        // React to XRAY completion even if Gmail tab never lost focus
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'fraudXrayFinished' && e.newValue === '1') {
+                localStorage.removeItem('fraudXrayFinished');
+                const box = document.getElementById('issue-summary-box');
+                if (box) box.style.display = 'block';
+                ensureIssueControls(true);
+                updateDetailVisibility();
+                if (currentContext && currentContext.orderNumber) {
+                    checkLastIssue(currentContext.orderNumber);
+                }
+            }
+        });
+
         // --- OPEN ORDER listener reutilizable ---
         function waitForElement(selector, timeout = 10000) {
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- listen for `storage` events so Gmail shows the Issues box when XRAY finishes even if the tab never lost focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68712f32393c8326b4fe949e0ba5f39c