### PR TITLE
Fix upload button label in Gmail Review Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ All notable changes to this project will be documented in this file.
 - Fixed SEARCH button triggering XRAY instead of opening Gmail and DB tabs.
 - Issues box in Gmail Review Mode now supports multiple document uploads.
   Uploaded files are converted to PDF before being sent and the button label
-  changes to **UPDATE** after each upload.
+  changes to **UPLOAD** after each upload.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1252,7 +1252,8 @@
                 if (list) list.remove();
             }
             let btn = document.getElementById('issue-resolve-btn');
-            const btnLabel = reviewMode ? 'COMMENT & RELEASE' : 'COMMENT & RESOLVE';
+            let btnLabel = reviewMode ? 'COMMENT & RELEASE' : 'COMMENT & RESOLVE';
+            if (droppedFiles.length) btnLabel = 'UPLOAD';
             if (!btn) {
                 btn = document.createElement('button');
                 btn.id = 'issue-resolve-btn';
@@ -1633,7 +1634,7 @@
                     msg.style.display = 'block';
                     setTimeout(() => { if (msg) msg.style.display = 'none'; }, 3000);
                     const btn = document.getElementById('issue-resolve-btn');
-                    if (btn && reviewMode) btn.textContent = 'UPDATE';
+                    if (btn && reviewMode) btn.textContent = 'UPLOAD';
                     droppedFiles = [];
                     const list = document.getElementById('dropped-file-list');
                     if (list) list.remove();


### PR DESCRIPTION
## Summary
- keep `UPLOAD` label when files are dropped in the Gmail issues box
- after a document upload completes the button text now resets to **UPLOAD**
- update changelog to reflect label change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687143855b4883268bc3e5ebb27982ce