### PR TITLE
Introduce base classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The extension lives in the `FENNEC/` folder. Key pieces include:
 - `core/` – Shared helpers and the service worker.
   - `background_email_search.js` – handles messaging, tab control and CORS removal for the local Mistral integration.
   - `utils.js` – common utilities such as copying text and opening search tabs.
+  - `sidebar.js` – `Sidebar` class used to build the sidebar container.
+  - `launcher.js` – base `Launcher` class for environment scripts.
   - `mistral_chat.js` – chat widget used when Dev Mode is enabled.
 - `environments/` – Content scripts injected into specific sites:
   - `gmail/gmail_launcher.js` – Gmail interface.
@@ -25,6 +27,13 @@ The extension lives in the `FENNEC/` folder. Key pieces include:
 - `README.md` – this guide.
 
 For historical changes refer to the **Changelog**. It has been reset so future updates start from a clean slate.
+
+### Object-oriented migration
+
+FENNEC began as purely procedural code. The new `sidebar.js` and `launcher.js` modules
+introduce basic classes so each environment can gradually adopt an object-oriented
+structure. Existing scripts still work as before; the classes are loaded globally
+and will be used incrementally in upcoming phases.
 
 ## Features
 

--- a/core/launcher.js
+++ b/core/launcher.js
@@ -1,0 +1,19 @@
+// Base Launcher class for FENNEC environments.
+// Concrete launchers should extend this class and implement the init() method.
+class Launcher {
+    constructor() {
+        this.sidebar = null;
+    }
+
+    detect() {
+        // Override with environment detection logic.
+        return true;
+    }
+
+    init() {
+        // Override with initialization steps for the environment.
+    }
+}
+
+// Expose globally.
+window.Launcher = Launcher;

--- a/core/sidebar.js
+++ b/core/sidebar.js
@@ -1,0 +1,41 @@
+// Sidebar class for FENNEC content scripts.
+// This wrapper helps move toward an object-oriented layout without breaking
+// existing procedural code. All methods rely on the same DOM structure used
+// previously.
+class Sidebar {
+    constructor(id = 'copilot-sidebar') {
+        this.id = id;
+        this.element = null;
+    }
+
+    exists() {
+        return document.getElementById(this.id);
+    }
+
+    build(html) {
+        const container = document.createElement('div');
+        container.id = this.id;
+        container.innerHTML = html;
+        this.element = container;
+    }
+
+    attach(parent = document.body) {
+        if (this.element && !this.exists()) {
+            parent.appendChild(this.element);
+        }
+    }
+
+    remove() {
+        const el = this.exists();
+        if (el) el.remove();
+    }
+
+    applyDesign(opts) {
+        if (typeof applySidebarDesign === 'function') {
+            applySidebarDesign(this.element, opts);
+        }
+    }
+}
+
+// Expose globally for existing scripts.
+window.Sidebar = Sidebar;

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -78,3 +78,6 @@ Retry button → Resends a prompt when the Mistral service is unavailable
 BOIR → Beneficial Ownership Information Report
 BETA → Early test version of Fennec
 Sidebar freeze → Mechanism locking sidebar data to the last processed order until XRAY runs again
+Launcher → Base class for page-specific scripts that inject the sidebar
+Sidebar → Class responsible for rendering sidebar HTML and applying styles
+Background Controller → Wrapper around the service worker handling tab reuse and message routing

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1442,9 +1442,8 @@
         function injectSidebar(mainPanels) {
             if (document.getElementById('copilot-sidebar')) return;
 
-            const sidebar = document.createElement('div');
-            sidebar.id = 'copilot-sidebar';
-            sidebar.innerHTML = `
+            const sbObj = new Sidebar();
+sbObj.build(`
                 <div class="copilot-header">
                     <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                     <div class="copilot-title">
@@ -1479,8 +1478,9 @@
                     ${devMode ? `<div class="copilot-footer"><button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button></div>` : ``}
                     <div class="copilot-footer"><button id="copilot-clear" class="copilot-button">🧹 CLEAR</button></div>
                 </div>
-            `;
-            document.body.appendChild(sidebar);
+            `);
+            sbObj.attach();
+            const sidebar = sbObj.element;
             chrome.storage.sync.get({
                 sidebarFontSize: 13,
                 sidebarFont: "'Inter', sans-serif",

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "core/pdf-lib.min.js",
         "environments/gmail/gmail_launcher.js"
       ],
@@ -45,6 +47,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "core/mistral_chat.js",
         "environments/db/db_launcher.js"
       ],
@@ -60,6 +64,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/db/tracker_fraud.js"
       ],
       "css": [
@@ -74,6 +80,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/db/db_email_search.js"
       ]
     },
@@ -84,6 +92,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/db/db_order_search.js"
       ]
     },
@@ -92,6 +102,8 @@
         "https://tools.usps.com/zip-code-lookup.htm*"
       ],
       "js": [
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/usps/usps_launcher.js"
       ]
     },
@@ -102,6 +114,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/adyen/adyen_launcher.js"
       ],
       "css": [
@@ -116,6 +130,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/txsos/tx_sos_launcher.js"
       ],
       "css": [
@@ -130,6 +146,8 @@
       "all_frames": true,
       "js": [
         "core/utils.js",
+        "core/sidebar.js",
+        "core/launcher.js",
         "environments/kount/kount_launcher.js"
       ]
     }


### PR DESCRIPTION
## Summary
- add `Sidebar` and `Launcher` classes
- load them for all content scripts via `manifest.json`
- rewrite Gmail sidebar injection to use `Sidebar`
- document object‑oriented migration in README
- define new terms in `dictionary.txt`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718b8ffe50832694639023c897df7e