### PR TITLE
Implement OOP migration phase 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ class ExampleLauncher extends Launcher {
 }
 
 new ExampleLauncher().init();
+
 ```
+
+Phase 3 introduces the `Floater` overlay framework. `TrialFloater` reuses it for the Fraud Review summary and a `BackgroundController` skeleton now wraps basic service worker actions. Future phases will migrate other overlays and messaging to these classes.
 
 ## Features
 

--- a/core/background_controller.js
+++ b/core/background_controller.js
@@ -1,0 +1,31 @@
+// Skeleton controller wrapping service worker message handling.
+class BackgroundController {
+    constructor() {
+        chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+            const fn = this[msg.action];
+            if (typeof fn === 'function') {
+                return fn.call(this, msg, sender, sendResponse);
+            }
+        });
+    }
+
+    openTab(msg, sender) {
+        const opts = { url: msg.url, active: Boolean(msg.active) };
+        if (msg.windowId) {
+            opts.windowId = msg.windowId;
+        } else if (sender && sender.tab) {
+            opts.windowId = sender.tab.windowId;
+        }
+        chrome.tabs.create(opts);
+    }
+
+    refocusTab() {
+        chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
+            if (fennecReturnTab) chrome.tabs.update(fennecReturnTab, { active: true });
+            chrome.storage.local.set({ fennecReturnTab: null });
+        });
+    }
+}
+
+self.BackgroundController = BackgroundController;
+self.fennecBackground = new BackgroundController();

--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -1,3 +1,4 @@
+import "./background_controller.js";
 // Background worker handling tab management and other extension messages
 // Use a declarative rule to strip the Origin header from local Mistral API
 // requests so Ollama accepts them without CORS errors.

--- a/core/floater.js
+++ b/core/floater.js
@@ -1,0 +1,41 @@
+// Base class for floating overlays used across environments.
+class Floater {
+    constructor(id, headerId = null, headerText = '') {
+        this.id = id;
+        this.headerId = headerId;
+        this.headerText = headerText;
+        this.element = null;
+        this.header = null;
+    }
+
+    exists() {
+        return document.getElementById(this.id);
+    }
+
+    build() {
+        this.element = document.createElement('div');
+        this.element.id = this.id;
+        if (this.headerId) {
+            this.header = document.createElement('div');
+            this.header.id = this.headerId;
+            this.header.textContent = this.headerText;
+        }
+    }
+
+    attach(parent = document.body) {
+        if (this.header && !document.getElementById(this.headerId)) {
+            parent.appendChild(this.header);
+        }
+        if (this.element && !this.exists()) {
+            parent.appendChild(this.element);
+        }
+    }
+
+    remove() {
+        if (this.element) this.element.remove();
+        if (this.header) this.header.remove();
+    }
+}
+
+// Expose globally for existing scripts.
+window.Floater = Floater;

--- a/core/trial_floater.js
+++ b/core/trial_floater.js
@@ -1,0 +1,33 @@
+// Floater used for the Fraud Review summary overlay.
+class TrialFloater extends Floater {
+    constructor() {
+        super('fennec-trial-overlay', 'fennec-trial-title', 'FRAUD REVIEW');
+    }
+
+    adjustHeader() {
+        if (!this.header) return;
+        const sidebarEl = document.getElementById('copilot-sidebar');
+        let baseSize = 13;
+        if (sidebarEl) {
+            const s = window.getComputedStyle(sidebarEl).fontSize;
+            const n = parseFloat(s);
+            if (!isNaN(n)) baseSize = n;
+        }
+        this.header.style.setProperty('font-size', (baseSize + 26) + 'px', 'important');
+        this.header.style.setProperty('line-height', '1.2', 'important');
+        this.header.style.setProperty('padding', '8px 0', 'important');
+        this.header.style.setProperty('border-radius', '12px', 'important');
+        this.header.style.setProperty('text-shadow', '0 0 4px #fff, 0 0 8px #fff', 'important');
+        this.header.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
+        this.header.style.setProperty('background-color', 'inherit', 'important');
+        this.header.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
+    }
+
+    ensure(parent = document.body) {
+        if (!this.element) this.build();
+        this.attach(parent);
+        this.adjustHeader();
+    }
+}
+
+window.TrialFloater = TrialFloater;

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -7,6 +7,7 @@
             document.body.classList.remove('fennec-light-mode');
         }
         const SIDEBAR_WIDTH = 340;
+        const trialFloater = new TrialFloater();
         chrome.storage.local.set({ fennecReviewMode: true });
         chrome.storage.sync.set({ fennecReviewMode: true });
 
@@ -474,9 +475,9 @@
         // Increase retries so the trial floater still appears.
         function showTrialFloater(retries = 60, force = false) {
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
-            const overlayExists = document.getElementById('fennec-trial-overlay');
+            const overlayExists = trialFloater.exists();
             if ((!flag && !force && !overlayExists) || retries <= 0) return;
-            const summary = document.getElementById('fraud-summary-box');
+            const summary = document.getElementById("fraud-summary-box");
             if (summary) summary.remove();
             chrome.storage.local.get({ adyenDnaInfo: null, kountInfo: null, sidebarOrderInfo: null }, data => {
                 if ((!data.adyenDnaInfo || !data.adyenDnaInfo.payment) && retries > 0) {
@@ -496,49 +497,9 @@
                 }
                 localStorage.setItem('fraudXrayFinished', '1');
                 chrome.runtime.sendMessage({ action: 'refocusTab' });
-                let overlay = document.getElementById('fennec-trial-overlay');
-                let title = document.getElementById('fennec-trial-title');
-                if (!overlay) {
-                    overlay = document.createElement('div');
-                    overlay.id = 'fennec-trial-overlay';
-                    title = document.createElement('div');
-                    title.id = 'fennec-trial-title';
-                    title.textContent = 'FRAUD REVIEW';
-                    const sidebarEl = document.getElementById('copilot-sidebar');
-                    let baseSize = 13;
-                    if (sidebarEl) {
-                        const s = window.getComputedStyle(sidebarEl).fontSize;
-                        const n = parseFloat(s);
-                        if (!isNaN(n)) baseSize = n;
-                    }
-                    title.style.setProperty('font-size', (baseSize + 26) + 'px', 'important');
-                    title.style.setProperty('line-height', '1.2', 'important');
-                    title.style.setProperty('padding', '8px 0', 'important');
-                    title.style.setProperty('border-radius', '12px', 'important');
-                    title.style.setProperty('text-shadow', '0 0 4px #fff, 0 0 8px #fff', 'important');
-                    title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
-                    title.style.setProperty('background-color', 'inherit', 'important');
-                    title.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
-                    document.body.appendChild(title);
-                    document.body.appendChild(overlay);
-                } else {
-                    // Ensure header styling persists if overlay already existed
-                    const sidebarEl2 = document.getElementById('copilot-sidebar');
-                    let baseSize2 = 13;
-                    if (sidebarEl2) {
-                        const s = window.getComputedStyle(sidebarEl2).fontSize;
-                        const n = parseFloat(s);
-                        if (!isNaN(n)) baseSize2 = n;
-                    }
-                    title.style.setProperty('font-size', (baseSize2 + 26) + 'px', 'important');
-                    title.style.setProperty('line-height', '1.2', 'important');
-                    title.style.setProperty('padding', '8px 0', 'important');
-                    title.style.setProperty('border-radius', '12px', 'important');
-                    title.style.setProperty('text-shadow', '0 0 4px #fff, 0 0 8px #fff', 'important');
-                    title.style.setProperty('box-shadow', '0 0 0 2px #fff inset', 'important');
-                    title.style.setProperty('background-color', 'inherit', 'important');
-                    title.style.setProperty('-webkit-text-stroke', '1px #fff', 'important');
-                }
+                trialFloater.ensure();
+                const overlay = trialFloater.element;
+                const title = trialFloater.header;
                 overlay.innerHTML = html;
                 const close = overlay.querySelector('.trial-close');
                 if (close) close.addEventListener('click', () => {

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "core/pdf-lib.min.js",
         "environments/gmail/gmail_launcher.js"
       ],
@@ -49,6 +51,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "core/mistral_chat.js",
         "environments/db/db_launcher.js"
       ],
@@ -66,6 +70,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/db/tracker_fraud.js"
       ],
       "css": [
@@ -82,6 +88,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/db/db_email_search.js"
       ]
     },
@@ -94,6 +102,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/db/db_order_search.js"
       ]
     },
@@ -104,6 +114,8 @@
       "js": [
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/usps/usps_launcher.js"
       ]
     },
@@ -116,6 +128,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/adyen/adyen_launcher.js"
       ],
       "css": [
@@ -132,6 +146,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/txsos/tx_sos_launcher.js"
       ],
       "css": [
@@ -148,6 +164,8 @@
         "core/utils.js",
         "core/sidebar.js",
         "core/launcher.js",
+        "core/floater.js",
+        "core/trial_floater.js",
         "environments/kount/kount_launcher.js"
       ]
     }


### PR DESCRIPTION
## Summary
- start phase 3 of the refactor
- add Floater base class and TrialFloater overlay
- add BackgroundController skeleton and load it in the service worker
- use TrialFloater in the Fraud Review page
- load new scripts across environments
- document the new phase in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687542debfa883268d4820b6d08e8523