### PR TITLE
Implement Phase 7 cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to this project will be documented in this file.
 - Added Messenger module to unify extension messaging across environments.
   Uploaded files are converted to PDF before being sent and the button label
   changes to **UPDATE** after each upload.
+- Removed deprecated showDiagnoseResults helper and finalized documentation.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Phase 5 expands `BackgroundController` with helpers like `openOrReuseTab` and `r
 Phase 6 adds a `Messenger` helper used by all environments to send and receive
 messages in a uniform way.
 
-Phase 7 will clean up deprecated helpers and finalize the documentation.
+Phase 7 removes obsolete helpers (such as the unused `showDiagnoseResults`
+stub) and finalizes this documentation.
 
 ## Features
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -2821,10 +2821,6 @@ class DBLauncher extends Launcher {
         Promise.all(promises).then(() => loading.remove());
     }
 
-    function showDiagnoseResults() {
-        // legacy function kept for compatibility
-    }
-
 function getLastHoldUser() {
         const trigger = document.querySelector("a[onclick*='modalTrackOrderHistory']");
         if (trigger) trigger.click();


### PR DESCRIPTION
## Summary
- finalize documentation for Phase 7
- remove deprecated `showDiagnoseResults` helper
- note change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755400dbf8832683eeb4ca18164279