### PR TITLE
Fix duplicated fraud review tabs

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -2872,6 +2872,8 @@ function getLastHoldUser() {
 
     function runFraudXray() {
         if (!fraudXray) return;
+        if (sessionStorage.getItem('fraudXrayStarted')) return;
+        sessionStorage.setItem('fraudXrayStarted', '1');
         if (localStorage.getItem('fraudXrayCompleted')) {
             fraudXray = false;
             return;

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -492,6 +492,7 @@
                     return;
                 }
                 sessionStorage.removeItem('fennecShowTrialFloater');
+                sessionStorage.removeItem('fraudXrayStarted');
                 if (data.sidebarOrderInfo && data.sidebarOrderInfo.orderId) {
                     localStorage.setItem('fraudXrayCompleted', String(data.sidebarOrderInfo.orderId));
                 } else {
@@ -993,6 +994,7 @@
             localStorage.removeItem('fraudXrayCompleted');
             localStorage.removeItem('fraudXrayFinished');
             sessionStorage.removeItem('fennecShowTrialFloater');
+            sessionStorage.removeItem('fraudXrayStarted');
             showInitialStatus();
         }
 

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1668,6 +1668,7 @@ sbObj.build(`
             loadKountSummary();
             if (localStorage.getItem('fraudXrayFinished') === '1') {
                 localStorage.removeItem('fraudXrayFinished');
+                sessionStorage.removeItem('fraudXrayStarted');
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);
@@ -1682,6 +1683,7 @@ sbObj.build(`
         window.addEventListener('storage', (e) => {
             if (e.key === 'fraudXrayFinished' && e.newValue === '1') {
                 localStorage.removeItem('fraudXrayFinished');
+                sessionStorage.removeItem('fraudXrayStarted');
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);


### PR DESCRIPTION
## Summary
- prevent multiple simultaneous Fraud Xray executions
- clear execution flag when Fraud Review ends
- remove flag in Gmail when Xray finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687560b0817c832688b71cb5020bc0a2