### PR TITLE
Refine trial floater layout

### DIFF
--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -13,7 +13,9 @@
                 const id = link ? link.textContent.replace(/\D+/g, '') : '';
                 const typeCell = r.querySelector('td:nth-child(4)');
                 const type = typeCell ? typeCell.textContent.trim() : '';
-                return { orderId: id, type };
+                const statusCell = r.querySelector('td:nth-child(5)');
+                const status = statusCell ? statusCell.textContent.trim() : '';
+                return { orderId: id, type, status };
             });
         }
 

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -15,7 +15,8 @@
                 let type = '';
                 if (cells.length >= 6) type = cells[5].textContent.trim();
                 else if (cells.length >= 4) type = cells[3].textContent.trim();
-                return { orderId: id, type };
+                const status = cells.length >= 5 ? cells[4].textContent.trim() : '';
+                return { orderId: id, type, status };
             });
         }
 

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -782,14 +782,15 @@
     margin-bottom: 8px;
 }
 #fennec-trial-overlay .trial-order {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 8px;
     border-radius: 12px;
     overflow: hidden;
 }
-#fennec-trial-overlay .trial-order .trial-col {
-    border-radius: 12px;
-}
+#fennec-trial-overlay .trial-info { flex: 1; }
+#fennec-trial-overlay .trial-action { display: flex; align-items: center; justify-content: center; }
 #fennec-trial-overlay .trial-order .trial-line {
     font-size: calc(var(--sb-font-size) + 6px);
     background: rgba(255,255,255,0.9);
@@ -813,6 +814,11 @@
 #fennec-trial-overlay .trial-order .trial-btn-line {
     margin-top: 4px;
 }
+#fennec-trial-overlay .trial-two-col { display:flex; justify-content: space-between; align-items:center; }
+#fennec-trial-overlay .trial-two-col .trial-tag { font-weight:bold; margin-right:4px; }
+#fennec-trial-overlay .trial-two-col .trial-value { flex:1; text-align:left; }
+#fennec-trial-overlay .member-list { margin:0; padding-left:16px; }
+#fennec-trial-overlay .trial-sep { border-bottom:1px solid #555; margin:4px 0; }
 #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
     background-color: rgba(46,204,113,0.99);
 }


### PR DESCRIPTION
## Summary
- adjust email search parsers to grab order status
- include status tallies for fraud check
- redesign trial floater header and DB column
- update overlay styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68757d1e6e988326ab3c2d292de63b56