### PR TITLE
Improve trial floater display

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -789,7 +789,7 @@
     border-radius: 12px;
     overflow: hidden;
 }
-#fennec-trial-overlay .trial-info { flex: 1; }
+#fennec-trial-overlay .trial-info { flex: 1; text-align: center; }
 #fennec-trial-overlay .trial-action { display: flex; align-items: center; justify-content: center; }
 #fennec-trial-overlay .trial-order .trial-line {
     font-size: calc(var(--sb-font-size) + 6px);
@@ -870,6 +870,7 @@
 #fennec-trial-overlay .trial-card-details {
     font-size: calc(var(--sb-font-size) + 1px);
 }
+#fennec-trial-overlay .trial-card-info { margin: 2px 0; }
 #fennec-trial-overlay .db-adyen-check {
     color: #0a0;
     margin-left: 4px;


### PR DESCRIPTION
## Summary
- tweak trial floater header tags and RA/VA labels
- show short expiry date and adjust card info layout
- add country detection utility for DB info
- highlight total orders ratio and list involved countries
- center header column in floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687588b49bcc832680372c85755b855a