### PR TITLE
Fix trial floater when opening tracker later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@ All notable changes to this project will be documented in this file.
 - Fixed duplicate tabs when triggering XRAY or SEARCH.
 - Fixed Trial floater not appearing after XRAY completion when the fraud tracker
   page was opened late.
+- Fixed Trial floater disappearing when reopening the fraud tracker after XRAY
+  had already finished.

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -1109,24 +1109,20 @@
 
         injectSidebar();
         scanOrders();
-        const manualOpen = !sessionStorage.getItem('fennecShowTrialFloater');
-        if (manualOpen) {
-            chrome.storage.local.set({ sidebarDb: [], sidebarOrderId: null, sidebarOrderInfo: null, adyenDnaInfo: null, kountInfo: null, sidebarFreezeId: null });
-            showInitialStatus();
-        } else {
-           loadDbSummary();
-           loadDnaSummary();
-           loadKountSummary();
-           // Ensure the trial overlay appears if XRAY finished before this
-           // page loaded by checking the persisted flag and showing the
-           // floater immediately.
-           if (localStorage.getItem('fraudXrayFinished') === '1') {
-               localStorage.removeItem('fraudXrayFinished');
-               showTrialFloater(60, true);
-           } else {
-               showTrialFloater(60, true);
-           }
-        }
+        chrome.storage.local.get({ fraudReviewSession: null }, ({ fraudReviewSession }) => {
+            let manualOpen = !sessionStorage.getItem('fennecShowTrialFloater');
+            const resume = manualOpen && fraudReviewSession;
+            if (resume) sessionStorage.setItem('fennecShowTrialFloater', '1');
+            if (manualOpen && !resume) {
+                chrome.storage.local.set({ sidebarDb: [], sidebarOrderId: null, sidebarOrderInfo: null, adyenDnaInfo: null, kountInfo: null, sidebarFreezeId: null });
+                showInitialStatus();
+            } else {
+                loadDbSummary();
+                loadDnaSummary();
+                loadKountSummary();
+                showTrialFloater(60, true);
+            }
+        });
         const clearBtn = document.getElementById('copilot-clear');
         if (clearBtn) clearBtn.onclick = clearSidebar;
 


### PR DESCRIPTION
## Summary
- adjust tracker logic to restore Trial Floater when re-opening the fraud tracker after XRAY has finished
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687677a8175083269638b269427ea564