### PR TITLE
Improve sidebar session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ GENERAL FEATURES:
 - When the sidebar is opened manually in Gmail or Adyen, it starts empty and only shows the action buttons. Order details appear after using SEARCH, DNA or XRAY.
 - Visiting the Fraud tracker in DB automatically opens the sidebar in Review Mode and adds 🩻 XRAY icons next to each order number.
 
+### Session handling
+FENNEC manages three session levels:
+- **Tab session** – the default per-tab state with no order information shown.
+- **Window session** – tabs in the same browser window share a session id so the sidebar stays in sync.
+- **Flow session** – when the sidebar opens new tabs or windows, the current session id propagates to maintain continuity.
+Opening a page outside an existing flow resets the sidebar to its initial view. The Gmail inbox never displays order details.
+
 ## Known limitations
 - The scripts rely on the browser DOM provided by Chrome.
   

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -4,18 +4,14 @@ class AdyenLauncher extends Launcher {
     init() {
     if (window.top !== window) return;
     const bg = fennecMessenger;
+    getFennecSessionId();
+    initializeFennecSession();
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC (POO)] Extension disabled, skipping Adyen launcher.');
             return;
         }
 
-        chrome.storage.local.get({ fennecActiveSession: null }, ({ fennecActiveSession }) => {
-            if (fennecActiveSession) {
-                sessionStorage.setItem('fennecSessionId', fennecActiveSession);
-            }
-            getFennecSessionId();
-        });
 
         try {
             const params = new URLSearchParams(window.location.search);

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -3,6 +3,8 @@
 (function persistentSidebar() {
     if (window.top !== window) return;
     const bg = fennecMessenger;
+    getFennecSessionId();
+    initializeFennecSession();
     // Clear the closed flag on full reloads so the sidebar returns
     window.addEventListener('beforeunload', () => {
         sessionStorage.removeItem("fennecSidebarClosed");
@@ -735,7 +737,7 @@
             if (link && orderId) {
                 link.addEventListener('click', (e) => {
                     e.preventDefault();
-                    bg.openActiveTab({ url });
+                    propagateFlowSession(() => bg.openActiveTab({ url }));
                 });
             }
             attachCommonListeners(summaryBox);
@@ -1412,7 +1414,7 @@
                 navigator.clipboard.writeText(context.email).catch(err => console.error("[FENNEC (POO)] Clipboard error:", err));
             }
 
-            const data = { fennecActiveSession: getFennecSessionId() };
+            const data = { fennecFlowSession: getFennecSessionId() };
             if (!xray) {
                 Object.assign(data, {
                     fraudReviewSession: null,
@@ -1840,7 +1842,7 @@ sbObj.build(`
                                 orderId,
                                 files: uploadList
                             },
-                            fennecActiveSession: getFennecSessionId()
+                            fennecFlowSession: getFennecSessionId()
                         }, () => {
                             const url = `https://db.incfile.com/storage/incfile/${orderId}`;
                             bg.openOrReuseTab({ url, active: false });
@@ -1859,7 +1861,7 @@ sbObj.build(`
                 }
                 const data = { orderId, comment };
                 if (reviewMode && !comment) data.release = true;
-                sessionSet({ fennecPendingComment: data, fennecActiveSession: getFennecSessionId() }, () => {
+                sessionSet({ fennecPendingComment: data, fennecFlowSession: getFennecSessionId() }, () => {
                     const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
                     bg.openOrReuseTab({ url, active: false });
                 });
@@ -1980,7 +1982,7 @@ sbObj.build(`
                         updates[key] = input.value.trim();
                     }
                 });
-                sessionSet({ fennecUpdateRequest: { orderId, updates }, fennecActiveSession: getFennecSessionId() }, () => {
+                sessionSet({ fennecUpdateRequest: { orderId, updates }, fennecFlowSession: getFennecSessionId() }, () => {
                     const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
                     bg.openOrReuseTab({ url, active: false });
                     overlay.remove();

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -68,7 +68,7 @@ class KountLauncher extends Launcher {
                         const ekataLink = document.querySelector('a[href*="/workflow/ekata"]');
                         if (ekataLink) {
                             const url = ekataLink.href.startsWith('http') ? ekataLink.href : location.origin + ekataLink.getAttribute('href');
-                            bg.openOrReuseTab({ url, active: true });
+                            propagateFlowSession(() => bg.openOrReuseTab({ url, active: true }));
                         }
                     }, 500);
                 };
@@ -101,7 +101,7 @@ class KountLauncher extends Launcher {
                         chrome.storage.local.get({ fennecFraudAdyen: null }, ({ fennecFraudAdyen }) => {
                             if (fennecFraudAdyen) {
                                 chrome.storage.local.remove('fennecFraudAdyen');
-                                bg.openOrReuseTab({ url: fennecFraudAdyen, active: true });
+                                propagateFlowSession(() => bg.openOrReuseTab({ url: fennecFraudAdyen, active: true }));
                             } else {
                                 bg.refocusTab();
                             }


### PR DESCRIPTION
## Summary
- add `initializeFennecSession` and `propagateFlowSession` helpers
- use new helpers in Gmail, DB, Adyen and Kount launchers
- propagate session when opening new tabs from flows
- document session handling in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68767d503d5c83269e692f941ee46fa7