### PR TITLE
Fix XRAY email search and tab focus

### DIFF
--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -557,9 +557,13 @@ class AdyenLauncher extends Launcher {
                     console.log('[FENNEC (POO) Adyen] DNA stats stored');
                     // Mark XRAY as finished so the Trial floater shows even if DB wasn't focused
                     localStorage.setItem('fraudXrayFinished', '1');
-                    chrome.storage.local.get({ sidebarOrderInfo: null }, ({ sidebarOrderInfo }) => {
-                        const email = sidebarOrderInfo ? sidebarOrderInfo.clientEmail : null;
-                        bg.send('focusDbSearch', { email });
+                    chrome.storage.local.get({ fraudReviewSession: null, sidebarOrderInfo: null }, ({ fraudReviewSession, sidebarOrderInfo }) => {
+                        if (fraudReviewSession) {
+                            bg.send('refocusTab');
+                        } else {
+                            const email = sidebarOrderInfo ? sidebarOrderInfo.clientEmail : null;
+                            bg.send('focusDbSearch', { email });
+                        }
                     });
                 });
             }

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -2903,7 +2903,7 @@ function getLastHoldUser() {
             bg.openOrReuseTab({ url: gmailUrl, active: true, refocus: true });
         }
         if (client.email) {
-            const searchUrl = `https://db.incfile.com/db-tools/scan-email-address?fennec_email=${encodeURIComponent(client.email)}`;
+            const searchUrl = `https://db.incfile.com/order-tracker/orders/order-search?fennec_email=${encodeURIComponent(client.email)}`;
             bg.openOrReuseTab({ url: searchUrl, active: false, refocus: true });
         }
         if (info.orderId) {


### PR DESCRIPTION
## Summary
- correct XRAY email search URL to use order-search
- when returning from Adyen during XRAY, refocus the original Fraud Review tab instead of reopening DB search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68768850068c8326b5896d4d78ed5287