### PR TITLE
Update trial floater layout

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -825,10 +825,12 @@
 }
 #fennec-trial-overlay .trial-two-col .trial-tag {
     font-weight: bold;
-    text-align: right;
+    text-align: left;
     margin-right: 0;
 }
-#fennec-trial-overlay .trial-two-col .trial-value { text-align: left; }
+#fennec-trial-overlay .trial-two-col .trial-value {
+    text-align: right;
+}
 #fennec-trial-overlay .member-list { margin:0; padding-left:16px; }
 #fennec-trial-overlay .trial-sep { border-bottom:1px solid #555; margin:4px 0; }
 #fennec-trial-overlay .trial-order.trial-header-green .trial-col {


### PR DESCRIPTION
## Summary
- adjust layout for trial floater information so label is left-aligned and value right-aligned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68768e0294fc832695bec53767d5f619