### PR TITLE
Fix trial floater column alignment

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -825,11 +825,11 @@
 }
 #fennec-trial-overlay .trial-two-col .trial-tag {
     font-weight: bold;
-    text-align: left;
+    text-align: right;
     margin-right: 0;
 }
 #fennec-trial-overlay .trial-two-col .trial-value {
-    text-align: right;
+    text-align: left;
 }
 #fennec-trial-overlay .member-list { margin:0; padding-left:16px; }
 #fennec-trial-overlay .trial-sep { border-bottom:1px solid #555; margin:4px 0; }


### PR DESCRIPTION
## Summary
- align label and value correctly in trial overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687691cc367c832692eeab1138a4752d