### PR TITLE
Enhance Trial Floater layout

### DIFF
--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -647,9 +647,15 @@
                             extraInfo.appendChild(div);
                         };
                         if (resp.statusCounts) {
-                            addLine(`<span class="trial-tag">CXL:</span><span class="trial-value">${resp.statusCounts.cxl}</span>`);
-                            addLine(`<span class="trial-tag">PENDING:</span><span class="trial-value">${resp.statusCounts.pending}</span>`);
-                            addLine(`<span class="trial-tag">SHIPPED:</span><span class="trial-value">${resp.statusCounts.shipped}</span>`);
+                            if (parseInt(resp.statusCounts.cxl, 10) > 0) {
+                                addLine(`<span class="trial-tag">CXL:</span><span class="trial-value">${resp.statusCounts.cxl}</span>`);
+                            }
+                            if (parseInt(resp.statusCounts.pending, 10) > 0) {
+                                addLine(`<span class="trial-tag">PENDING:</span><span class="trial-value">${resp.statusCounts.pending}</span>`);
+                            }
+                            if (parseInt(resp.statusCounts.shipped, 10) > 0) {
+                                addLine(`<span class="trial-tag">SHIPPED:</span><span class="trial-value">${resp.statusCounts.shipped}</span>`);
+                            }
                             if (extraInfo) {
                                 const sep = document.createElement('div');
                                 sep.className = 'trial-line trial-sep';

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -819,17 +819,19 @@
 }
 #fennec-trial-overlay .trial-two-col {
     display: grid;
-    grid-template-columns: max-content 1fr;
+    grid-template-columns: 30% 1fr;
     align-items: center;
     column-gap: 4px;
 }
 #fennec-trial-overlay .trial-two-col .trial-tag {
-    font-weight: bold;
+    font-weight: normal;
+    font-size: calc(var(--sb-font-size) - 1px);
     text-align: right;
     margin-right: 0;
 }
 #fennec-trial-overlay .trial-two-col .trial-value {
     text-align: left;
+    font-weight: bold;
 }
 #fennec-trial-overlay .member-list { margin:0; padding-left:16px; }
 #fennec-trial-overlay .trial-sep { border-bottom:1px solid #555; margin:4px 0; }

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -115,6 +115,22 @@
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-btn-line {
     margin-top: 4px;
 }
+.fennec-light-mode #fennec-trial-overlay .trial-two-col {
+    display: grid;
+    grid-template-columns: 30% 1fr;
+    align-items: center;
+    column-gap: 4px;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-two-col .trial-tag {
+    font-weight: normal;
+    font-size: calc(var(--sb-font-size) - 1px);
+    text-align: right;
+    margin-right: 0;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-two-col .trial-value {
+    text-align: left;
+    font-weight: bold;
+}
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-col {
     background-color: rgba(46,204,113,0.99);
 }


### PR DESCRIPTION
## Summary
- adjust two-column layout in Trial Floater for DB/Adyen/Kount sections
- hide order status lines when value is zero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687694e87cfc8326ad4798d9c7e3cc3d