### PR TITLE
Center trial action button in header

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -790,7 +790,13 @@
     overflow: hidden;
 }
 #fennec-trial-overlay .trial-info { flex: 1; text-align: center; }
-#fennec-trial-overlay .trial-action { display: flex; align-items: center; justify-content: center; }
+#fennec-trial-overlay .trial-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 12px;
+    min-width: 160px;
+}
 #fennec-trial-overlay .trial-order .trial-line {
     font-size: calc(var(--sb-font-size) + 6px);
     background: rgba(255,255,255,0.9);


### PR DESCRIPTION
## Summary
- center the suggested action button in the Trial floater header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687699382530832694afc99b45d1f9dc