### PR TITLE
Add client info and trial floater fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@ All notable changes to this project will be documented in this file.
 - Set fraudXrayFinished when data is extracted so the Trial floater shows even if DB tab wasn't open.
 - DB email search is now opened in the background during XRAY and focused after DNA extraction.
 - Fixed duplicate "Orders Found" lines in the Trial floater.
+- Fixed Trial floater not showing after XRAY completion.
+- Added CLIENT and COUNTRIES INVOLVED lines to the DB box in the Trial floater.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1823,7 +1823,8 @@ class DBLauncher extends Launcher {
             raExpired,
             orderCost: getOrderCost(),
             clientLtv: client.ltv,
-            clientEmail: client.email
+            clientEmail: client.email,
+            clientName: client.name
         };
         sessionSet({
             sidebarDb: dbSections,


### PR DESCRIPTION
## Summary
- show client name and countries in Fraud Review trial floater
- persist client name in sidebar order info
- ensure trial floater appears if XRAY finished before opening the tracker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a39b36308326b04d4c4b2c4bd4d9