### PR TITLE
Fix XRAY return focus and update fraud checks

### DIFF
--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -287,12 +287,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
                 } else {
                     const orders = Array.isArray(resp.orders) ? resp.orders : [];
-                    const counts = { cxl: 0, pending: 0, shipped: 0 };
+                    const counts = { cxl: 0, pending: 0, shipped: 0, transferred: 0 };
                     orders.forEach(o => {
                         const s = String(o.status || '').toUpperCase();
                         if (/CANCEL/.test(s)) counts.cxl++;
-                        else if (/PROCESSING|REVIEW|HOLD|TRANSFERRED/.test(s)) counts.pending++;
+                        else if (/TRANSFERRED/.test(s)) counts.transferred++;
                         else if (/SHIPPED/.test(s)) counts.shipped++;
+                        else if (/PROCESSING|REVIEW|HOLD/.test(s)) counts.pending++;
                     });
                     counts.total = orders.length;
                     sendResponse({ orderCount: orders.length, statusCounts: counts, activeSubs: [], ltv: message.ltv });

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -2901,11 +2901,11 @@ function getLastHoldUser() {
         if (!client.email && parts.length) {
             const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
             const gmailUrl = 'https://mail.google.com/mail/u/0/#search/' + query;
-            bg.openOrReuseTab({ url: gmailUrl, active: true, refocus: true });
+            bg.openOrReuseTab({ url: gmailUrl, active: true });
         }
         if (client.email) {
             const searchUrl = `https://db.incfile.com/order-tracker/orders/order-search?fennec_email=${encodeURIComponent(client.email)}`;
-            bg.openOrReuseTab({ url: searchUrl, active: false, refocus: true });
+            bg.openOrReuseTab({ url: searchUrl, active: false });
         }
         if (info.orderId) {
             const adyenUrl = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${info.orderId}`;


### PR DESCRIPTION
## Summary
- keep Fraud Tracker tab active after XRAY by not refocusing when opening search pages
- improve email match logic and compare client name with members
- only show member checkmarks when there is a match
- adjust order statistics: new transferred count and better pending/completed ratio
- update TOTAL and P/ORDER calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876a8f5ff3483269f69361a35608ebc