### PR TITLE
Update trial floater layout and validation

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -842,9 +842,24 @@
     text-align: left;
     font-weight: bold;
 }
+#fennec-trial-overlay .trial-four-col {
+    display: grid;
+    grid-template-columns: 30% 1fr 30% 1fr;
+    align-items: center;
+    column-gap: 4px;
+}
+#fennec-trial-overlay .trial-four-col .trial-tag {
+    font-weight: normal;
+    font-size: calc(var(--sb-font-size) - 1px);
+    text-align: right;
+}
+#fennec-trial-overlay .trial-four-col .trial-value {
+    text-align: left;
+    font-weight: bold;
+}
 #fennec-trial-overlay .member-list {
     margin: 0;
-    padding-left: 16px;
+    padding-left: 0;
     list-style: none;
 }
 #fennec-trial-overlay .trial-sep { border-bottom:1px solid #555; margin:4px 0; }

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -142,9 +142,24 @@
     text-align: left;
     font-weight: bold;
 }
+.fennec-light-mode #fennec-trial-overlay .trial-four-col {
+    display: grid;
+    grid-template-columns: 30% 1fr 30% 1fr;
+    align-items: center;
+    column-gap: 4px;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-four-col .trial-tag {
+    font-weight: normal;
+    font-size: calc(var(--sb-font-size) - 1px);
+    text-align: right;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-four-col .trial-value {
+    text-align: left;
+    font-weight: bold;
+}
 .fennec-light-mode #fennec-trial-overlay .member-list {
     margin: 0;
-    padding-left: 16px;
+    padding-left: 0;
     list-style: none;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-col {


### PR DESCRIPTION
## Summary
- tweak member list spacing and add four column layout classes
- collect US states for trial floater and rename countries line
- allow partial name matches for client validation
- reorganize Kount section and rename VIP Declines label
- adjust suggested action logic to ignore minor crosses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876b0f4c2a883268621806ed7df1ec5