### PR TITLE
Fix Gmail duplicate tabs and refresh sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
   changes to **UPDATE** after each upload.
 - Removed deprecated showDiagnoseResults helper and finalized documentation.
 - Fixed duplicate tabs when triggering XRAY or SEARCH.
+- Fixed Gmail sidebar not refreshing after XRAY and avoided double DB and Gmail tabs when using SEARCH or XRAY.
 - Fixed Trial floater not appearing after XRAY completion when the fraud tracker
   page was opened late.
 - Fixed Trial floater disappearing when reopening the fraud tracker after XRAY

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -35,6 +35,7 @@
             let currentContext = null;
             let storedOrderInfo = null;
             let droppedFiles = [];
+            let searchInProgress = false;
             const updateFloater = new UpdateFloater();
 
             function dedupeFiles(list) {
@@ -1374,6 +1375,8 @@
         }
 
         function handleEmailSearchClick(xray = false) {
+            if (searchInProgress) return;
+            searchInProgress = true;
             showLoadingState();
 
             const context = extractOrderContextFromEmail();
@@ -1436,6 +1439,7 @@
             }
             sessionSet(data, () => {
                 bg.replaceTabs({ urls });
+                setTimeout(() => { searchInProgress = false; }, 1000);
             });
             if (orderId) {
                 checkLastIssue(orderId);
@@ -1664,8 +1668,7 @@ sbObj.build(`
         // Ensure DNA summary refreshes when returning from Adyen
         // and show comment controls once XRAY completes.
         window.addEventListener('focus', () => {
-            loadDnaSummary();
-            loadKountSummary();
+            refreshSidebar();
             if (localStorage.getItem('fraudXrayFinished') === '1') {
                 localStorage.removeItem('fraudXrayFinished');
                 const box = document.getElementById('issue-summary-box');
@@ -1682,6 +1685,7 @@ sbObj.build(`
         window.addEventListener('storage', (e) => {
             if (e.key === 'fraudXrayFinished' && e.newValue === '1') {
                 localStorage.removeItem('fraudXrayFinished');
+                refreshSidebar();
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);


### PR DESCRIPTION
## Summary
- avoid concurrently replacing tabs
- prevent repeated searches in Gmail sidebar
- refresh Gmail sidebar when returning from XRAY
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876c4e287388326b45a1b2f9bb79280