### PR TITLE
Update order search queue view

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -1174,3 +1174,12 @@
     animation: fennecFlash 1s infinite;
 }
 
+#copilot-sidebar .state-count {
+    padding: 2px 0;
+}
+
+#copilot-sidebar .state-count.active {
+    text-decoration: underline;
+    font-weight: bold;
+}
+


### PR DESCRIPTION
## Summary
- add per-state filter handling in DB order search summary
- render state counts in four-column layout
- apply underline style to active state filter
- remove `EXTENSION IS WORKING ON` legend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876dda1f4e48326bfd5cc087e802b4e