### PR TITLE
Fix queue CSV capture under CSP

### DIFF
--- a/environments/db/csv_hook.js
+++ b/environments/db/csv_hook.js
@@ -1,0 +1,14 @@
+(function() {
+    if (window.__fennecCsvHook) return;
+    window.__fennecCsvHook = true;
+    const origBlob = window.Blob;
+    window.Blob = function(data, opts) {
+        if (Array.isArray(data) && typeof data[0] === 'string') {
+            try {
+                window.postMessage({ type: 'FENNEC_CSV_CAPTURE', csv: data[0] }, '*');
+            } catch (e) {}
+            window.Blob = origBlob;
+        }
+        return new origBlob(data, opts);
+    };
+})();

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -191,20 +191,7 @@
 
         function injectCsvHook() {
             const script = document.createElement('script');
-            script.textContent = `(
-                function() {
-                    if (window.__fennecCsvHook) return;
-                    window.__fennecCsvHook = true;
-                    const origBlob = window.Blob;
-                    window.Blob = function(data, opts) {
-                        if (Array.isArray(data) && typeof data[0] === 'string') {
-                            try { window.postMessage({ type: 'FENNEC_CSV_CAPTURE', csv: data[0] }, '*'); } catch (e) {}
-                            window.Blob = origBlob;
-                        }
-                        return new origBlob(data, opts);
-                    };
-                }
-            )();`;
+            script.src = chrome.runtime.getURL('environments/db/csv_hook.js');
             document.documentElement.appendChild(script);
             script.remove();
         }

--- a/manifest.json
+++ b/manifest.json
@@ -204,7 +204,8 @@
       "resources": [
         "fennec_icon.png",
         "bg_holo.mp4",
-        "mistral-7b-instruct-v0.1.Q4_K_M.gguf"
+        "mistral-7b-instruct-v0.1.Q4_K_M.gguf",
+        "environments/db/csv_hook.js"
       ],
       "matches": [
         "<all_urls>"


### PR DESCRIPTION
## Summary
- extract CSV hook to standalone file so it's loaded via `src`
- load the hook file in `db_order_search.js`
- expose hook file via `web_accessible_resources`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c3f57b688326a77143002643ac15