### PR TITLE
Fix queue view scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 - Added CLIENT and COUNTRIES INVOLVED lines to the DB box in the Trial floater.
 - Queue View CSV results now update Order Search summary and apply orange flags with console logs for debugging.
 - Fixed QUEUE flow only downloading CSV instead of executing full scan.
+- Restored opening the Fraud Review page and manual CSV button click so the queue view fully refreshes.

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -364,6 +364,20 @@
             }
             console.log('[FENNEC] Starting queue scan...');
             if (icon) icon.classList.add('fennec-flash');
+
+            // Open the Fraud Review queue immediately so IDs are collected even if
+            // the CSV download fails.
+            bg.openOrReuseTab({ url: 'https://db.incfile.com/order-tracker/orders/fraud?fennec_queue_scan=1', active: false });
+
+            // Trigger the standard CSV download in case the custom request fails.
+            const genBtn = document.getElementById('generateCSV');
+            if (genBtn) {
+                console.log('[FENNEC] Triggering built-in CSV download button');
+                genBtn.click();
+            } else {
+                console.warn('[FENNEC] generateCSV button not found');
+            }
+
             downloadCsvOrders(orders => {
                 if (icon) icon.classList.remove('fennec-flash');
                 if (progress) {
@@ -378,7 +392,6 @@
                 injectCsvOrders(orders);
                 highlightMatches(ids);
                 showCsvSummary(orders);
-                bg.openOrReuseTab({ url: 'https://db.incfile.com/order-tracker/orders/fraud?fennec_queue_scan=1', active: false });
             });
         }
 


### PR DESCRIPTION
## Summary
- open Fraud Review page and trigger built-in CSV button before downloading
- document fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d2588b6883269e29f63e74d90ad0