### PR TITLE
Fix Order Search count retrieval

### DIFF
--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -275,30 +275,50 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "detectSubscriptions" && message.email && sender.tab) {
         const winId = sender.tab.windowId;
         const encoded = encodeURIComponent(message.email);
-        chrome.tabs.query({ windowId: winId }, tabs => {
-            const searchTab = tabs.find(t => t.url && t.url.includes("/order-tracker/orders/order-search") && t.url.includes("fennec_email=" + encoded));
-            if (!searchTab) {
-                sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
-                return;
-            }
-            chrome.tabs.update(searchTab.id, { active: true });
-            chrome.tabs.sendMessage(searchTab.id, { action: 'getEmailOrders' }, resp => {
-                if (chrome.runtime.lastError || !resp) {
+        chrome.storage.local.get({ fennecDbSearchTab: null }, data => {
+            const fetchOrders = (tab) => {
+                if (!tab) {
                     sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
-                } else {
-                    const orders = Array.isArray(resp.orders) ? resp.orders : [];
-                    const counts = { cxl: 0, pending: 0, shipped: 0, transferred: 0 };
-                    orders.forEach(o => {
-                        const s = String(o.status || '').toUpperCase();
-                        if (/CANCEL/.test(s)) counts.cxl++;
-                        else if (/TRANSFERRED/.test(s)) counts.transferred++;
-                        else if (/SHIPPED/.test(s)) counts.shipped++;
-                        else if (/PROCESSING|REVIEW|HOLD/.test(s)) counts.pending++;
-                    });
-                    counts.total = orders.length;
-                    sendResponse({ orderCount: orders.length, statusCounts: counts, activeSubs: [], ltv: message.ltv });
+                    return;
                 }
-            });
+                chrome.tabs.update(tab.id, { active: true }, () => {
+                    chrome.tabs.sendMessage(tab.id, { action: 'getEmailOrders' }, resp => {
+                        if (chrome.runtime.lastError || !resp) {
+                            sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
+                        } else {
+                            const orders = Array.isArray(resp.orders) ? resp.orders : [];
+                            const counts = { cxl: 0, pending: 0, shipped: 0, transferred: 0 };
+                            orders.forEach(o => {
+                                const s = String(o.status || '').toUpperCase();
+                                if (/CANCEL/.test(s)) counts.cxl++;
+                                else if (/TRANSFERRED/.test(s)) counts.transferred++;
+                                else if (/SHIPPED/.test(s)) counts.shipped++;
+                                else if (/PROCESSING|REVIEW|HOLD/.test(s)) counts.pending++;
+                            });
+                            counts.total = orders.length;
+                            sendResponse({ orderCount: orders.length, statusCounts: counts, activeSubs: [], ltv: message.ltv });
+                        }
+                    });
+                });
+            };
+
+            if (data.fennecDbSearchTab) {
+                chrome.tabs.get(data.fennecDbSearchTab, tab => {
+                    if (chrome.runtime.lastError || !tab) {
+                        chrome.tabs.query({ windowId: winId }, tabs => {
+                            const found = tabs.find(t => t.url && t.url.includes("/order-tracker/orders/order-search") && t.url.includes("fennec_email=" + encoded));
+                            fetchOrders(found);
+                        });
+                    } else {
+                        fetchOrders(tab);
+                    }
+                });
+            } else {
+                chrome.tabs.query({ windowId: winId }, tabs => {
+                    const searchTab = tabs.find(t => t.url && t.url.includes("/order-tracker/orders/order-search") && t.url.includes("fennec_email=" + encoded));
+                    fetchOrders(searchTab);
+                });
+            }
         });
         return true;
     }

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -661,9 +661,7 @@ class DBLauncher extends Launcher {
                             if (client.email) parts.push(`"${client.email}"`);
                             if (client.name) parts.push(`"${client.name}"`);
                             if (parts.length && client.email) {
-                                const base = 'https://db.incfile.com/order-tracker/orders/order-search';
-                                const url = base + '?fennec_email=' + encodeURIComponent(client.email);
-                                bg.openActiveTab({ url });
+                                bg.send('focusDbSearch', { email: client.email });
                             } else if (parts.length) {
                                 const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
                                 const url = 'https://mail.google.com/mail/u/0/#search/' + query;


### PR DESCRIPTION
## Summary
- ensure detectSubscriptions uses the stored DB search tab when available
- register the search tab when opening email search from the DB quick actions menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877dc5e3d9483268c3621dde1b83944