### PR TITLE
Fix order search count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ All notable changes to this project will be documented in this file.
 - Queue View CSV results now update Order Search summary and apply orange flags with console logs for debugging.
 - Fixed QUEUE flow only downloading CSV instead of executing full scan.
 - Restored opening the Fraud Review page and manual CSV button click so the queue view fully refreshes.
+- Fixed Order Search count remaining at 0 when DB email search results were available.

--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -276,7 +276,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         const winId = sender.tab.windowId;
         const encoded = encodeURIComponent(message.email);
         chrome.tabs.query({ windowId: winId }, tabs => {
-            const searchTab = tabs.find(t => t.url && t.url.includes("/order-tracker/orders/order-search") && t.url.includes("fennec_email=" + encoded));
+            const searchTabs = tabs.filter(t => t.url && t.url.includes("/order-tracker/orders/order-search"));
+            let searchTab = searchTabs.find(t => t.url.includes("fennec_email=" + encoded));
+            if (!searchTab) searchTab = searchTabs[0];
             if (!searchTab) {
                 sendResponse({ orderCount: 0, activeSubs: [], ltv: message.ltv });
                 return;


### PR DESCRIPTION
## Summary
- fallback to any DB order search tab when detecting subscriptions
- document fix for Order Search count in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877dc5e3d9483268c3621dde1b83944