### PR TITLE
Fix order search email results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ All notable changes to this project will be documented in this file.
 - Restored opening the Fraud Review page and manual CSV button click so the queue view fully refreshes.
 - Fixed Order Search count remaining at 0 when DB email search results were available.
 - Fixed Orders Found count staying at 0 when only the legacy DB email search page was open.
+- Fixed Orders Found count not updating when using the newer Order Search page.

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -512,6 +512,13 @@
                 highlightMatches();
             }
         });
+
+        chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
+            if (msg.action === 'getEmailOrders') {
+                const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
+                sendResponse({ orders });
+            }
+        });
     });
 })();
 


### PR DESCRIPTION
## Summary
- send email order info from the newer order-search page
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e3ce66a48326b37136b8d33a6123