### PR TITLE
Fix CSV order injection in Order Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ All notable changes to this project will be documented in this file.
 - Fixed Order Search count remaining at 0 when DB email search results were available.
 - Fixed Orders Found count staying at 0 when only the legacy DB email search page was open.
 - Fixed Orders Found count not updating when using the newer Order Search page.
+- Fixed CSV order injection failing with "$ is not defined" on Order Search.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The extension FENNEC (POO) lives in the `FENNEC/` folder. Key pieces include:
 - `environments/` – Content scripts injected into specific sites:
   - `gmail/gmail_launcher.js` – Gmail interface.
   - `db/db_launcher.js` – Internal order pages.
+  - `db/csv_hook.js` – Captures CSV downloads in Order Search.
+  - `db/table_inject.js` – Injects new rows into the results table using jQuery.
   - `adyen/adyen_launcher.js` – Adyen payment pages.
   - `txsos/tx_sos_launcher.js` – Texas SOS filing site.
   - `usps/usps_launcher.js` – USPS address verification.

--- a/environments/db/AGENTS.md
+++ b/environments/db/AGENTS.md
@@ -6,3 +6,5 @@ Scripts destinados al panel interno de órdenes (DB).
 - **db_email_search.js** – Abre resultados de correo según la orden.
 - **db_order_search.js** – Utilidad para localizar órdenes desde el popup.
 - **tracker_fraud.js** – Vista reducida para el panel de fraude.
+- **csv_hook.js** – Intercepta la descarga de CSV para capturar las órdenes.
+- **table_inject.js** – Permite añadir filas al DataTable usando jQuery de la página.

--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -1,0 +1,21 @@
+(function(){
+    if (window.__fennecTableInject) return;
+    window.__fennecTableInject = true;
+    window.addEventListener('message', function(e) {
+        if (e.source !== window || !e.data || e.data.type !== 'FENNEC_ADD_ROWS') return;
+        try {
+            var $ = window.jQuery || window.$;
+            if (!$) return;
+            var tableEl = document.getElementById('tableStatusResults');
+            if (!tableEl || typeof $(tableEl).DataTable !== 'function') return;
+            var table = $(tableEl).DataTable();
+            (e.data.rows || []).forEach(function(html){
+                table.row.add($(html)[0]);
+            });
+            table.draw(false);
+            window.postMessage({ type: 'FENNEC_ROWS_ADDED' }, '*');
+        } catch (err) {
+            console.error('[FENNEC] table_inject error', err);
+        }
+    });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -205,7 +205,8 @@
         "fennec_icon.png",
         "bg_holo.mp4",
         "mistral-7b-instruct-v0.1.Q4_K_M.gguf",
-        "environments/db/csv_hook.js"
+        "environments/db/csv_hook.js",
+        "environments/db/table_inject.js"
       ],
       "matches": [
         "<all_urls>"


### PR DESCRIPTION
## Summary
- add helper script to inject rows using page jQuery
- load new helper from db_order_search and manifest
- document helper scripts in README and AGENTS
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877eab95034832689a85fa8cd3af45f