### PR TITLE
Fix Trial floater order count delay

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -534,8 +534,34 @@
 
         chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
             if (msg.action === 'getEmailOrders') {
-                const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
-                sendResponse({ orders });
+                const send = () => {
+                    const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
+                    sendResponse({ orders });
+                };
+                const initial = collectOrders();
+                if (initial.length) {
+                    send();
+                } else {
+                    const tbody = document.querySelector('#tableStatusResults tbody');
+                    if (!tbody) { send(); return; }
+                    let done = false;
+                    const obs = new MutationObserver(() => {
+                        if (!done && collectOrders().length) {
+                            done = true;
+                            obs.disconnect();
+                            send();
+                        }
+                    });
+                    obs.observe(tbody, { childList: true });
+                    setTimeout(() => {
+                        if (!done) {
+                            done = true;
+                            obs.disconnect();
+                            send();
+                        }
+                    }, 10000);
+                    return true;
+                }
             }
         });
     });

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -683,6 +683,16 @@
                     const kount = data.kountInfo;
                     const order = data.sidebarOrderInfo;
                     const req = ++subDetectSeq;
+                    const cols = overlay.querySelectorAll('.trial-columns .trial-col');
+                    const dbCol = cols && cols[0];
+                    const extraInfo = dbCol ? dbCol.querySelector('#db-extra-info') : null;
+                    let orderLine = null;
+                    if (extraInfo) {
+                        orderLine = document.createElement('div');
+                        orderLine.className = 'trial-line trial-two-col';
+                        orderLine.innerHTML = '<span class="trial-tag">Orders Found:</span><span class="trial-value">LOADING...</span>';
+                        extraInfo.appendChild(orderLine);
+                    }
                     bg.send('detectSubscriptions', {
                         email: order.clientEmail,
                         ltv: order.clientLtv || ''
@@ -739,13 +749,15 @@
                                     div.innerHTML = `<span class="trial-tag">STATES:</span><span class="trial-value">${states.join(', ')}</span>`;
                                     extraInfo.appendChild(div);
                                 }
-                                if (countries.length) {
-                                    const div = document.createElement('div');
-                                    div.className = 'trial-line trial-two-col trial-countries-line';
-                                    div.innerHTML = `<span class="trial-tag">COUNTRIES:</span><span class="trial-value">${countries.join(', ')}</span>`;
-                                    extraInfo.appendChild(div);
-                                }
+                            if (countries.length) {
+                                const div = document.createElement('div');
+                                div.className = 'trial-line trial-two-col trial-countries-line';
+                                div.innerHTML = `<span class="trial-tag">COUNTRIES:</span><span class="trial-value">${countries.join(', ')}</span>`;
+                                extraInfo.appendChild(div);
                             }
+                        }
+                        if (orderLine) {
+                            orderLine.innerHTML = `<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`;
                         } else {
                             addLine(`<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`);
                         }


### PR DESCRIPTION
## Summary
- handle `getEmailOrders` requests asynchronously so we wait for DOM results
- show a `LOADING...` placeholder for Orders Found in the Trial floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877eb3c6a888326b7fe4fe0324a482f