### PR TITLE
Fix order count loading in Trial Floater

### DIFF
--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -52,7 +52,20 @@
 
         chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
             if (msg.action === 'getEmailOrders') {
-                sendResponse({ orders: collectOrders() });
+                const sendOrders = () => sendResponse({ orders: collectOrders() });
+                const tbody = document.querySelector('.search_result tbody');
+                if (tbody && !tbody.querySelector('tr')) {
+                    const obs = new MutationObserver(() => {
+                        if (tbody.querySelector('tr')) {
+                            obs.disconnect();
+                            sendOrders();
+                        }
+                    });
+                    obs.observe(tbody, { childList: true });
+                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 10000);
+                    return true;
+                }
+                sendOrders();
             }
         });
     });

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -534,8 +534,23 @@
 
         chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
             if (msg.action === 'getEmailOrders') {
-                const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
-                sendResponse({ orders });
+                const sendOrders = () => {
+                    const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
+                    sendResponse({ orders });
+                };
+                const tbody = document.querySelector('#tableStatusResults tbody');
+                if (tbody && !tbody.querySelector('tr')) {
+                    const obs = new MutationObserver(() => {
+                        if (tbody.querySelector('tr')) {
+                            obs.disconnect();
+                            sendOrders();
+                        }
+                    });
+                    obs.observe(tbody, { childList: true });
+                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 10000);
+                    return true;
+                }
+                sendOrders();
             }
         });
     });

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -560,6 +560,16 @@
                         const dna = data.adyenDnaInfo;
                         const kount = data.kountInfo;
                         const order = data.sidebarOrderInfo;
+                        const dbCol = overlay.querySelector('.trial-col');
+                        let loadingLine = null;
+                        if (dbCol) {
+                            loadingLine = document.createElement('div');
+                            loadingLine.className = 'trial-line';
+                            loadingLine.textContent = 'Orders: LOADING...';
+                            const raVa = dbCol.querySelector('.ra-va-line');
+                            if (raVa && raVa.nextSibling) dbCol.insertBefore(loadingLine, raVa.nextSibling);
+                            else dbCol.appendChild(loadingLine);
+                        }
                         bg.send('detectSubscriptions', {
                             email: (order && order.clientEmail) || '',
                             ltv: (order && order.clientLtv) || ''
@@ -567,14 +577,18 @@
                             if (req !== subDetectSeq) return;
                             subBtn.disabled = false;
                             if (!resp) return;
-                            const dbCol = overlay.querySelector('.trial-col');
-                            if (!dbCol) return;
-                            const line1 = document.createElement('div');
-                            line1.className = 'trial-line';
-                            line1.textContent = `Orders: ${resp.orderCount}`;
-                            const raVa = dbCol.querySelector('.ra-va-line');
-                            if (raVa && raVa.nextSibling) dbCol.insertBefore(line1, raVa.nextSibling);
-                            else dbCol.appendChild(line1);
+                            const col = overlay.querySelector('.trial-col');
+                            if (!col) return;
+                            if (loadingLine) loadingLine.textContent = `Orders: ${resp.orderCount}`;
+                            else {
+                                const line1 = document.createElement('div');
+                                line1.className = 'trial-line';
+                                line1.textContent = `Orders: ${resp.orderCount}`;
+                                const raVa = col.querySelector('.ra-va-line');
+                                if (raVa && raVa.nextSibling) col.insertBefore(line1, raVa.nextSibling);
+                                else col.appendChild(line1);
+                                loadingLine = line1;
+                            }
                             let line2 = null;
                             if (resp.ltv) {
                                 const ratio = resp.orderCount && parseFloat(resp.ltv) ? (resp.orderCount / parseFloat(resp.ltv)).toFixed(2) : 'N/A';
@@ -682,6 +696,18 @@
                     const dna = data.adyenDnaInfo;
                     const kount = data.kountInfo;
                     const order = data.sidebarOrderInfo;
+                    const cols = overlay.querySelectorAll('.trial-columns .trial-col');
+                    const dbCol = cols && cols[0];
+                    let loadingLine = null;
+                    if (dbCol) {
+                        const extraInfo = dbCol.querySelector('#db-extra-info');
+                        if (extraInfo) {
+                            loadingLine = document.createElement('div');
+                            loadingLine.className = 'trial-line trial-two-col orders-loading';
+                            loadingLine.innerHTML = '<span class="trial-tag">Orders Found:</span><span class="trial-value">LOADING...</span>';
+                            extraInfo.appendChild(loadingLine);
+                        }
+                    }
                     const req = ++subDetectSeq;
                     bg.send('detectSubscriptions', {
                         email: order.clientEmail,
@@ -689,8 +715,6 @@
                     }, resp => {
                         if (req !== subDetectSeq) return;
                         if (!resp) return;
-                        const cols = overlay.querySelectorAll('.trial-columns .trial-col');
-                        const dbCol = cols && cols[0];
                         if (!dbCol) return;
                         const extraInfo = dbCol.querySelector('#db-extra-info');
                         const addLine = html => {
@@ -746,6 +770,8 @@
                                     extraInfo.appendChild(div);
                                 }
                             }
+                        } else if (loadingLine) {
+                            loadingLine.innerHTML = `<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`;
                         } else {
                             addLine(`<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`);
                         }


### PR DESCRIPTION
## Summary
- wait for order search results to appear before responding to `getEmailOrders`
- show 'Orders Found: LOADING...' in the Trial floater until counts return
- update sub detection button to display loading text while fetching counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877eb3c6a888326b7fe4fe0324a482f