### PR TITLE
Fix queue view fraud match and csv table injection

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -450,9 +450,11 @@
                 console.log('[FENNEC] Injecting CSV orders into search results table');
                 injectCsvOrders(orders);
 
-                const ids = orders.filter(o => /possible fraud/i.test(o.status)).map(o => o.id);
-                console.log(`[FENNEC] Flagging ${ids.length} possible fraud orders`);
-                highlightMatches(ids);
+                const ids = orders.map(o => String(o.id));
+                const flagged = ids.filter(id => fraudSet.has(id));
+                console.log(`[FENNEC] Flagging ${flagged.length} possible fraud orders`);
+                // Highlight all known fraud orders including the new matches
+                highlightMatches(Array.from(fraudSet));
             });
         }
 

--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -10,9 +10,10 @@
             if (!tableEl || typeof $(tableEl).DataTable !== 'function') return;
             var table = $(tableEl).DataTable();
             (e.data.rows || []).forEach(function(html){
-                table.row.add($(html)[0]);
+                table.row.add($(html));
             });
-            table.draw(false);
+            // Show all rows so injected orders are visible
+            table.page.len(-1).draw(false);
             window.postMessage({ type: 'FENNEC_ROWS_ADDED' }, '*');
         } catch (err) {
             console.error('[FENNEC] table_inject error', err);


### PR DESCRIPTION
## Summary
- handle fraud id comparison against captured Fraud Review list
- ensure CSV rows are appended and all rows shown in table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877ef010ce88326916d647d0620e9f5