### PR TITLE
Fix Trial floater order counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,5 @@ All notable changes to this project will be documented in this file.
 - Fixed Orders Found count staying at 0 when only the legacy DB email search page was open.
 - Fixed Orders Found count not updating when using the newer Order Search page.
 - Fixed CSV order injection failing with "$ is not defined" on Order Search.
+- Fixed Orders Found value always showing 0 and removed the line from the Trial
+  floater. The TOTAL line now reflects the real count once results load.

--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -62,7 +62,7 @@
                         }
                     });
                     obs.observe(tbody, { childList: true });
-                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 10000);
+                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 30000);
                     return true;
                 }
                 sendOrders();

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -561,7 +561,7 @@
                         }
                     });
                     obs.observe(tbody, { childList: true });
-                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 10000);
+                    setTimeout(() => { obs.disconnect(); sendOrders(); }, 30000);
                     return true;
                 }
                 sendOrders();

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -698,16 +698,6 @@
                     const order = data.sidebarOrderInfo;
                     const cols = overlay.querySelectorAll('.trial-columns .trial-col');
                     const dbCol = cols && cols[0];
-                    let loadingLine = null;
-                    if (dbCol) {
-                        const extraInfo = dbCol.querySelector('#db-extra-info');
-                        if (extraInfo) {
-                            loadingLine = document.createElement('div');
-                            loadingLine.className = 'trial-line trial-two-col orders-loading';
-                            loadingLine.innerHTML = '<span class="trial-tag">Orders Found:</span><span class="trial-value">LOADING...</span>';
-                            extraInfo.appendChild(loadingLine);
-                        }
-                    }
                     const req = ++subDetectSeq;
                     bg.send('detectSubscriptions', {
                         email: order.clientEmail,
@@ -770,10 +760,6 @@
                                     extraInfo.appendChild(div);
                                 }
                             }
-                        } else if (loadingLine) {
-                            loadingLine.innerHTML = `<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`;
-                        } else {
-                            addLine(`<span class="trial-tag">Orders Found:</span><span class="trial-value">${resp.orderCount}</span>`);
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- increase waiting time when reading DB email search results
- remove `Orders Found` line from the Trial floater
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f03566288326911cfda41a40376e