### PR TITLE
Add debug logs for email search totals

### DIFF
--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -52,7 +52,11 @@
 
         chrome.runtime.onMessage.addListener((msg, snd, sendResponse) => {
             if (msg.action === 'getEmailOrders') {
-                const sendOrders = () => sendResponse({ orders: collectOrders() });
+                const sendOrders = () => {
+                    const orders = collectOrders();
+                    console.log('[FENNEC (POO)] db_email_search returning', orders.length, 'orders');
+                    sendResponse({ orders });
+                };
                 const tbody = document.querySelector('.search_result tbody');
                 if (tbody && !tbody.querySelector('tr')) {
                     const obs = new MutationObserver(() => {

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -552,6 +552,7 @@
             if (msg.action === 'getEmailOrders') {
                 const sendOrders = () => {
                     const orders = collectOrders().map(o => ({ orderId: o.id, type: '', status: o.status }));
+                    console.log('[FENNEC (POO)] db_order_search returning', orders.length, 'orders');
                     sendResponse({ orders });
                 };
                 const tbody = document.querySelector('#tableStatusResults tbody');

--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -515,6 +515,7 @@
         // DNA info may take a while to load for very large records.
         // Increase retries so the trial floater still appears.
         function showTrialFloater(retries = 60, force = false) {
+            console.log('[FENNEC (POO)] showTrialFloater', { retries, force });
             const flag = sessionStorage.getItem('fennecShowTrialFloater');
             const overlayExists = trialFloater.exists();
             if ((!flag && !force && !overlayExists) || retries <= 0) return;
@@ -542,6 +543,7 @@
                     floaterRefocusDone = true;
                 }
                 trialFloater.ensure();
+                console.log('[FENNEC (POO)] Trial floater displayed');
                 const overlay = trialFloater.element;
                 const title = trialFloater.header;
                 overlay.innerHTML = html;
@@ -574,6 +576,7 @@
                             email: (order && order.clientEmail) || '',
                             ltv: (order && order.clientLtv) || ''
                         }, resp => {
+                            console.log('[FENNEC (POO)] email search result', resp);
                             if (req !== subDetectSeq) return;
                             subBtn.disabled = false;
                             if (!resp) return;
@@ -703,6 +706,7 @@
                         email: order.clientEmail,
                         ltv: order.clientLtv || ''
                     }, resp => {
+                        console.log('[FENNEC (POO)] email search result', resp);
                         if (req !== subDetectSeq) return;
                         if (!resp) return;
                         if (!dbCol) return;
@@ -722,6 +726,7 @@
                             extraInfo.appendChild(div);
                         };
                         if (resp.statusCounts) {
+                            console.log('[FENNEC (POO)] Email search status counts', resp.statusCounts);
                             const pairs = [];
                             if (parseInt(resp.statusCounts.cxl, 10) > 0) pairs.push(['CXL', resp.statusCounts.cxl]);
                             if (parseInt(resp.statusCounts.pending, 10) > 0) pairs.push(['PENDING', resp.statusCounts.pending]);


### PR DESCRIPTION
## Summary
- add more verbose logs when fetching email orders
- log order counts in DB email search pages
- report trial floater display events and email search counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f2a564f88326b224783e94a531c6