### PR TITLE
Fix queue view row injection

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -388,10 +388,15 @@
                         `  <button target="_blank" data-view-link="https://db.incfile.com/incfile/order/detail/${o.id}" class="btn btn-primary btn-sm btn-rounded view_comp_detail pull-right" style="margin-left:5px;width:60px">View</button>` +
                         `<button style="width:60px" class="btn btn-danger btn-sm btn-rounded copy pull-right" data-comp-name="${escapeHtml(o.name || '')}" data-name-search-link="https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx">Search</button></div></td>` +
                         `<td>${escapeHtml(o.status || '')}</td>` +
+                        `<td></td>` +
                         `<td>${expedited}</td>` +
                         `<td>${escapeHtml(o.state || '')}</td>` +
-                        `<td></td><td></td>` +
+                        `<td></td>` +
+                        `<td></td>` +
+                        `<td>${escapeHtml(o.forwardedDate || '')}</td>` +
                         `<td>${escapeHtml(o.orderedDate || '')}</td>` +
+                        `<td>${escapeHtml(o.expectedDate || '')}</td>` +
+                        `<td>${escapeHtml(o.shippingDate || '')}</td>` +
                         `<td><div class="checkbox checkbox-primary"> <input type="checkbox" class="chk_to_print" id="ord_${o.id}" value="${o.id}"> <label for="ord_${o.id}">&nbsp;</label> </div></td>` +
                         `</tr>`;
                     rows.push(rowHtml);

--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -10,8 +10,8 @@
             if (!tableEl || typeof $(tableEl).DataTable !== 'function') return;
             var table = $(tableEl).DataTable();
             (e.data.rows || []).forEach(function(html){
-                var row = $(html)[0];
-                if (row) table.row.add(row);
+                var $row = $(html);
+                if ($row.length) table.row.add($row);
             });
             // Show all rows so injected orders are visible
             table.page.len(-1).draw(false);


### PR DESCRIPTION
## Summary
- update `table_inject` to use jQuery objects when adding rows
- pad injected queue rows with hidden columns so DataTables accepts them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f845553c832682e2dc9ca662061d