### PR TITLE
Fix trial floater order count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable changes to this project will be documented in this file.
 - Fixed Orders Found value always showing 0 and removed the line from the Trial
   floater. The TOTAL line now reflects the real count once results load.
 - Separated order counting from subscription detection and added COUNTEMAILORDERS action.
+- Added retries when counting email orders so the Trial floater shows accurate totals.


### PR DESCRIPTION
## Summary
- retry when fetching email orders to wait for the search tab to load
- document change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877fca72c848326b45e901d3dc39e89