### PR TITLE
Suppress DataTables Ajax error in queue view

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -439,6 +439,14 @@
             // the CSV download fails.
             bg.openOrReuseTab({ url: 'https://db.incfile.com/order-tracker/orders/fraud?fennec_queue_scan=1', active: false });
 
+            // Suppress DataTables' default Ajax error alert which appears when
+            // triggering the CSV download. The table data is injected manually
+            // so the failed Ajax request is harmless.
+            const jq = window.jQuery || window.$;
+            if (jq && jq.fn && jq.fn.dataTable) {
+                jq.fn.dataTable.ext.errMode = 'none';
+            }
+
             // Trigger the standard CSV download in case the custom request fails.
             const genBtn = document.getElementById('generateCSV');
             if (genBtn) {


### PR DESCRIPTION
## Summary
- avoid DataTables Ajax error when running **QUEUE VIEW** by disabling default `errMode` before triggering the CSV download

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877fd913bd08326826590d4684ce63a