### PR TITLE
Fix DataTables alert in queue view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ All notable changes to this project will be documented in this file.
   floater. The TOTAL line now reflects the real count once results load.
 - Separated order counting from subscription detection and added COUNTEMAILORDERS action.
 - Added retries when counting email orders so the Trial floater shows accurate totals.
+- Suppressed DataTables Ajax error during Queue View.

--- a/environments/db/datatables_patch.js
+++ b/environments/db/datatables_patch.js
@@ -1,0 +1,8 @@
+(function(){
+    if (window.__fennecDtPatch) return;
+    window.__fennecDtPatch = true;
+    var jq = window.jQuery || window.$;
+    if (jq && jq.fn && jq.fn.dataTable) {
+        jq.fn.dataTable.ext.errMode = 'none';
+    }
+})();

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -306,9 +306,16 @@
             applyFilters();
         }
 
-        function injectCsvHook() {
+       function injectCsvHook() {
+           const script = document.createElement('script');
+           script.src = chrome.runtime.getURL('environments/db/csv_hook.js');
+           document.documentElement.appendChild(script);
+           script.remove();
+       }
+
+        function injectDatatablesPatch() {
             const script = document.createElement('script');
-            script.src = chrome.runtime.getURL('environments/db/csv_hook.js');
+            script.src = chrome.runtime.getURL('environments/db/datatables_patch.js');
             document.documentElement.appendChild(script);
             script.remove();
         }
@@ -439,13 +446,9 @@
             // the CSV download fails.
             bg.openOrReuseTab({ url: 'https://db.incfile.com/order-tracker/orders/fraud?fennec_queue_scan=1', active: false });
 
-            // Suppress DataTables' default Ajax error alert which appears when
-            // triggering the CSV download. The table data is injected manually
-            // so the failed Ajax request is harmless.
-            const jq = window.jQuery || window.$;
-            if (jq && jq.fn && jq.fn.dataTable) {
-                jq.fn.dataTable.ext.errMode = 'none';
-            }
+            // Suppress DataTables Ajax error alerts in the page context so the
+            // warning dialog doesn't appear when the built-in request fails.
+            injectDatatablesPatch();
 
             // Trigger the standard CSV download in case the custom request fails.
             const genBtn = document.getElementById('generateCSV');


### PR DESCRIPTION
## Summary
- suppress DataTables Ajax warning inside page by injecting script
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877ff91fb1c8326b59d0e86a5ae7f1c