### PR TITLE
Improve DB order row detection

### DIFF
--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -7,9 +7,13 @@
         const email = params.get('fennec_email');
         if (!email) return;
         function collectOrders() {
-            const rows = document.querySelectorAll(
+            let rows = document.querySelectorAll(
                 '.search_result tbody tr, #tableStatusResults tbody tr'
             );
+            if (!rows.length) {
+                const table = document.querySelector('table.dataTable');
+                if (table) rows = table.querySelectorAll('tbody tr');
+            }
             return Array.from(rows).map(r => {
                 const link = r.querySelector('a[href*="/order/detail/"]');
                 const id = link ? link.textContent.replace(/\D+/g, '') : '';
@@ -24,7 +28,7 @@
         function getTotalCount() {
             const info = document.querySelector('.dataTables_info');
             if (info) {
-                const m = info.textContent.match(/of\s+(\d+)\s+entries/i);
+                const m = info.textContent.match(/of\s+(\d+)\s+(?:entries|results)/i);
                 if (m) return parseInt(m[1], 10);
             }
             return collectOrders().length;

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -30,8 +30,10 @@
         }
 
         function collectOrders() {
-            const rows = document.querySelectorAll('#tableStatusResults tbody tr');
-            const headerCells = Array.from(document.querySelectorAll('#tableStatusResults thead th'));
+            let table = document.querySelector('#tableStatusResults');
+            if (!table) table = document.querySelector('table.dataTable');
+            const rows = table ? table.querySelectorAll('tbody tr') : [];
+            const headerCells = table ? Array.from(table.querySelectorAll('thead th')) : [];
             const colIndex = { status: -1, state: -1, expedited: -1, ordered: -1 };
             headerCells.forEach((th, idx) => {
                 const txt = th.textContent.trim().toLowerCase();
@@ -67,7 +69,7 @@
         function getTotalCount() {
             const info = document.querySelector('.dataTables_info');
             if (info) {
-                const m = info.textContent.match(/of\s+(\d+)\s+entries/i);
+                const m = info.textContent.match(/of\s+(\d+)\s+(?:entries|results)/i);
                 if (m) return parseInt(m[1], 10);
             }
             return collectOrders().length;


### PR DESCRIPTION
## Summary
- search fallback tables in DB email search/order search
- parse both "entries" and "results" in order count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687858d5831c83268f6dacacb0e7b001