### PR TITLE
Update DB trial floater calculations

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -875,6 +875,9 @@
 #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
 #fennec-trial-overlay .trial-col-title {
     font-weight: bold;
@@ -900,6 +903,9 @@
 
 #fennec-trial-overlay .trial-line {
     margin: 4px 0;
+}
+#fennec-trial-overlay .trial-center {
+    text-align: center;
 }
 #fennec-trial-overlay .trial-company-name {
     font-size: calc(var(--sb-font-size) + 12px);

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -109,6 +109,9 @@
     display: block;
     width: 100%;
 }
+.fennec-light-mode #fennec-trial-overlay .trial-center {
+    text-align: center;
+}
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-line.no-highlight {
     background: none;
 }
@@ -174,6 +177,9 @@
 .fennec-light-mode #fennec-trial-overlay .trial-col-wrap {
     flex: 1;
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-col-title {
     font-weight: bold;


### PR DESCRIPTION
## Summary
- enhance regex for email comparison in DB trial floater
- show total orders as a centered row with separator line
- compute P/ORDER as (total minus cancellations) over LTV
- vertically align trial floater columns to the top

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68785e8083b88326ac8d420ea5882935