### PR TITLE
Fix P/ORDER calc and adjust trial layout

### DIFF
--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -767,10 +767,11 @@
                                 addCenter(`TOTAL: ${resp.statusCounts.total} <span class="${goodTotal ? 'db-adyen-check' : 'db-adyen-cross'}">${goodTotal ? '✔' : '✖'}</span>`);
                                 addSep();
                                 if (resp.ltv) {
-                                    const openOrders = (parseInt(resp.statusCounts.total,10) || 0) - (parseInt(resp.statusCounts.cxl,10) || 0);
-                                    const ltvNum = parseFloat(resp.ltv) || 0;
-                                    const orderVal = ltvNum > 0 ? (openOrders / ltvNum).toFixed(2) : '0';
-                                    addFour([['LTV', resp.ltv], ['P/ORDER', orderVal]]);
+                                    const openOrders = (parseInt(resp.statusCounts.total, 10) || 0) -
+                                                        (parseInt(resp.statusCounts.cxl, 10) || 0);
+                                    const ltvNum = parseFloat(String(resp.ltv).replace(/[^0-9.]/g, '')) || 0;
+                                    const ratio = ltvNum > 0 ? `$${(openOrders / ltvNum).toFixed(2)}` : '$0.00';
+                                    addFour([['LTV', resp.ltv], ['P/ORDER', ratio]]);
                                 }
                                 const states = collectStates(order, dna, kount);
                                 const countries = collectCountries(order, dna, kount);

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -783,7 +783,7 @@
 }
 #fennec-trial-overlay .trial-order {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     margin-bottom: 8px;
     border-radius: 12px;
@@ -796,7 +796,7 @@
 #fennec-trial-overlay .trial-action {
     flex: 0 0 25%;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     padding: 0 12px;
 }
@@ -829,7 +829,7 @@
 #fennec-trial-overlay .trial-two-col {
     display: grid;
     grid-template-columns: 30% 1fr;
-    align-items: center;
+    align-items: flex-start;
     column-gap: 4px;
 }
 #fennec-trial-overlay .trial-two-col .trial-tag {
@@ -845,7 +845,7 @@
 #fennec-trial-overlay .trial-four-col {
     display: grid;
     grid-template-columns: 30% 1fr 30% 1fr;
-    align-items: center;
+    align-items: flex-start;
     column-gap: 4px;
 }
 #fennec-trial-overlay .trial-four-col .trial-tag {
@@ -1000,7 +1000,7 @@
     text-align: left;
     margin-bottom: 2px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .update-value {

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -93,7 +93,7 @@
 .fennec-light-mode #fennec-trial-overlay .trial-action {
     flex: 0 0 25%;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     padding: 0 12px;
 }
@@ -132,7 +132,7 @@
 .fennec-light-mode #fennec-trial-overlay .trial-two-col {
     display: grid;
     grid-template-columns: 30% 1fr;
-    align-items: center;
+    align-items: flex-start;
     column-gap: 4px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-two-col .trial-tag {
@@ -148,7 +148,7 @@
 .fennec-light-mode #fennec-trial-overlay .trial-four-col {
     display: grid;
     grid-template-columns: 30% 1fr 30% 1fr;
-    align-items: center;
+    align-items: flex-start;
     column-gap: 4px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-four-col .trial-tag {
@@ -425,7 +425,7 @@
     text-align: left;
     margin-bottom: 2px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .fennec-light-mode .update-value {


### PR DESCRIPTION
## Summary
- compute P/ORDER based on open orders divided by numeric LTV
- display the value in dollars
- vertically align trial boxes to the top in both themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687861c09ca48326855353dcbf6b48d5