### PR TITLE
Update trial floater layout

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -790,11 +790,12 @@
     overflow: hidden;
 }
 #fennec-trial-overlay .trial-info {
-    flex: 0 0 75%;
+    flex: 0 0 66%;
     text-align: center;
+    background: #d3d3d3;
 }
 #fennec-trial-overlay .trial-action {
-    flex: 0 0 25%;
+    flex: 0 0 33%;
     display: flex;
     align-items: flex-start;
     justify-content: center;
@@ -872,8 +873,17 @@
 #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
     background-color: rgba(139,0,0,0.99);
 }
+#fennec-trial-overlay .trial-order.trial-header-green .trial-action {
+    background-color: rgba(46,204,113,0.99);
+}
+#fennec-trial-overlay .trial-order.trial-header-purple .trial-action {
+    background-color: rgba(128,0,128,0.99);
+}
+#fennec-trial-overlay .trial-order.trial-header-red .trial-action {
+    background-color: rgba(139,0,0,0.99);
+}
 #fennec-trial-overlay .trial-col-wrap {
-    flex: 1;
+    flex: 0 0 33%;
     text-align: center;
     display: flex;
     flex-direction: column;
@@ -1125,25 +1135,33 @@
 
 .trial-action-btn {
     border: 1px solid #ccc;
-    border-radius: 6px;
+    border-radius: 20px;
     padding: 4px 10px;
     background-color: #fff;
     color: #000;
     font-weight: bold;
     cursor: pointer;
+    transition: transform 0.2s;
 }
 
 .trial-btn-cr { background-color: #fff; color: #000; }
 .trial-btn-id { background-color: #fff; color: #000; }
 .trial-btn-release { background-color: #fff; color: #000; }
 
-.trial-action-btn:hover { opacity: 0.9; }
+.trial-action-btn:hover {
+    opacity: 0.9;
+    transform: scale(1.1);
+}
 
 .big-trial-btn {
     font-size: calc(var(--sb-font-size) + 7px);
     padding: 6px 14px;
     margin-left: 0;
-    opacity: 0.5;
+    border-radius: 20px;
+    transition: transform 0.2s;
+}
+.big-trial-btn:hover {
+    transform: scale(1.1);
 }
 
 #fennec-trial-overlay.trial-header-green { background-color: rgba(46,46,46,0.98); }

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -87,11 +87,12 @@
     overflow: hidden;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-info {
-    flex: 0 0 75%;
+    flex: 0 0 66%;
     text-align: center;
+    background: #d3d3d3;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-action {
-    flex: 0 0 25%;
+    flex: 0 0 33%;
     display: flex;
     align-items: flex-start;
     justify-content: center;
@@ -174,8 +175,17 @@
 .fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-red .trial-col {
     background-color: rgba(139,0,0,0.99);
 }
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-action {
+    background-color: rgba(46,204,113,0.99);
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-purple .trial-action {
+    background-color: rgba(128,0,128,0.99);
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-red .trial-action {
+    background-color: rgba(139,0,0,0.99);
+}
 .fennec-light-mode #fennec-trial-overlay .trial-col-wrap {
-    flex: 1;
+    flex: 0 0 33%;
     text-align: center;
     display: flex;
     flex-direction: column;
@@ -201,22 +211,30 @@
 }
 .fennec-light-mode #fennec-trial-overlay .trial-action-btn {
     border: 1px solid #ccc;
-    border-radius: 6px;
+    border-radius: 20px;
     padding: 4px 10px;
     background-color: #fff;
     color: #000;
     font-weight: bold;
     cursor: pointer;
+    transition: transform 0.2s;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-btn-cr { background-color: #fff; color: #000; }
 .fennec-light-mode #fennec-trial-overlay .trial-btn-id { background-color: #fff; color: #000; }
 .fennec-light-mode #fennec-trial-overlay .trial-btn-release { background-color: #fff; color: #000; }
-.fennec-light-mode #fennec-trial-overlay .trial-action-btn:hover { opacity: 0.9; }
+.fennec-light-mode #fennec-trial-overlay .trial-action-btn:hover {
+    opacity: 0.9;
+    transform: scale(1.1);
+}
 .fennec-light-mode #fennec-trial-overlay .big-trial-btn {
     font-size: calc(var(--sb-font-size) + 7px);
     padding: 6px 14px;
     margin-left: 0;
-    opacity: 0.5;
+    border-radius: 20px;
+    transition: transform 0.2s;
+}
+.fennec-light-mode #fennec-trial-overlay .big-trial-btn:hover {
+    transform: scale(1.1);
 }
 .fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(255,255,255,0.98); }
 .fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(255,255,255,0.98); }


### PR DESCRIPTION
## Summary
- style trial floater header with 66/33 split
- match action colors with trial result and unify column widths
- mimic `SUB DETECTION` style for trial action buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687864cd26288326beb27031fcf1d6ec