### PR TITLE
Adjust Trial Floater layout

### DIFF
--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -689,7 +689,7 @@
                     if (srcBtn) {
                         const bigBtn = srcBtn.cloneNode(true);
                         bigBtn.id = '';
-                        bigBtn.classList.add('big-trial-btn');
+                        bigBtn.classList.add('big-trial-btn', 'sub-detect-btn');
                         bigBtn.addEventListener('click', () => handleTrialAction(selector));
                         bigSpot.appendChild(bigBtn);
                     }

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -784,21 +784,41 @@
 #fennec-trial-overlay .trial-order {
     display: flex;
     align-items: flex-start;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 12px;
     margin-bottom: 8px;
     border-radius: 12px;
     overflow: hidden;
 }
 #fennec-trial-overlay .trial-info {
-    flex: 0 0 75%;
+    flex: 0 0 66%;
     text-align: center;
+    background: #d3d3d3;
+    color: #000;
+    padding: 8px;
+    border-radius: 8px;
+    word-break: break-word;
 }
 #fennec-trial-overlay .trial-action {
-    flex: 0 0 25%;
+    flex: 0 0 33%;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
-    padding: 0 12px;
+    padding: 8px;
+    border-radius: 8px;
+    word-break: break-word;
+}
+#fennec-trial-overlay .trial-order.trial-header-green .trial-action {
+    background-color: rgba(46,204,113,0.99);
+    color: #fff;
+}
+#fennec-trial-overlay .trial-order.trial-header-purple .trial-action {
+    background-color: rgba(128,0,128,0.99);
+    color: #fff;
+}
+#fennec-trial-overlay .trial-order.trial-header-red .trial-action {
+    background-color: rgba(139,0,0,0.99);
+    color: #fff;
 }
 #fennec-trial-overlay .trial-order .trial-line {
     font-size: calc(var(--sb-font-size) + 6px);
@@ -883,6 +903,8 @@
     font-weight: bold;
     color: #fff;
     margin-bottom: 2px;
+    text-align: center;
+    width: 100%;
 }
 #fennec-trial-overlay .trial-col {
     text-align: center;
@@ -890,6 +912,7 @@
     color: #000;
     padding: 8px;
     border-radius: 8px;
+    word-break: break-word;
 }
 #fennec-trial-overlay .trial-summary {
     display: flex;
@@ -903,6 +926,7 @@
 
 #fennec-trial-overlay .trial-line {
     margin: 4px 0;
+    word-break: break-word;
 }
 #fennec-trial-overlay .trial-center {
     text-align: center;

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -85,17 +85,39 @@
     margin-bottom: 8px;
     border-radius: 12px;
     overflow: hidden;
+    display: flex;
+    justify-content: flex-start;
+    gap: 12px;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-info {
-    flex: 0 0 75%;
+    flex: 0 0 66%;
     text-align: center;
+    background: #d3d3d3;
+    color: #000;
+    padding: 8px;
+    border-radius: 8px;
+    word-break: break-word;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-action {
-    flex: 0 0 25%;
+    flex: 0 0 33%;
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
-    padding: 0 12px;
+    padding: 8px;
+    border-radius: 8px;
+    word-break: break-word;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-green .trial-action {
+    background-color: rgba(46,204,113,0.99);
+    color: #fff;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-purple .trial-action {
+    background-color: rgba(128,0,128,0.99);
+    color: #fff;
+}
+.fennec-light-mode #fennec-trial-overlay .trial-order.trial-header-red .trial-action {
+    background-color: rgba(139,0,0,0.99);
+    color: #fff;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-order .trial-col {
     border-radius: 12px;
@@ -108,6 +130,7 @@
     border-radius: 4px;
     display: block;
     width: 100%;
+    word-break: break-word;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-center {
     text-align: center;
@@ -185,6 +208,8 @@
     font-weight: bold;
     color: #fff;
     margin-bottom: 2px;
+    text-align: center;
+    width: 100%;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-col {
     text-align: center;
@@ -192,6 +217,7 @@
     color: #000;
     padding: 8px;
     border-radius: 8px;
+    word-break: break-word;
 }
 .fennec-light-mode #fennec-trial-overlay .trial-actions {
     display: flex;


### PR DESCRIPTION
## Summary
- tweak Trial Floater layout with two-column header
- keep DB, ADYEN and KOUNT boxes equal width
- copy Sub Detection button styling for suggested action
- ensure wrapping and centered titles for light and dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68786864043c8326a05970f08c75b4b2