### PR TITLE
Fix decision button visibility and tab refocus

### DIFF
--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -1290,6 +1290,7 @@ function namesMatch(a, b) {
             sessionStorage.removeItem('fennecShowTrialFloater');
             floaterRefocusDone = false;
             showInitialStatus();
+            bg.refocusTab();
         }
 
         function showInitialStatus() {

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -1161,6 +1161,10 @@
     padding: 6px 14px;
     margin-left: 0;
     opacity: 1;
+    background-color: #fff;
+    color: #000;
+    font-weight: bold;
+    border: 1px solid #ccc;
 }
 
 #fennec-trial-overlay.trial-header-green { background-color: rgba(46,46,46,0.98); }

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -236,6 +236,10 @@
     padding: 6px 14px;
     margin-left: 0;
     opacity: 1;
+    background-color: #fff;
+    color: #000;
+    font-weight: bold;
+    border: 1px solid #ccc;
 }
 .fennec-light-mode #fennec-trial-overlay.trial-header-green { background-color: rgba(255,255,255,0.98); }
 .fennec-light-mode #fennec-trial-overlay.trial-header-purple { background-color: rgba(255,255,255,0.98); }


### PR DESCRIPTION
## Summary
- style big decision button so text is visible
- same styles for light mode
- refocus the Fraud orders tab after XRAY cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791cb454488326a7ce577ab4afe232