### PR TITLE
Ensure fraud queue tab regains focus

### DIFF
--- a/environments/db/tracker_fraud.js
+++ b/environments/db/tracker_fraud.js
@@ -539,10 +539,11 @@
                     localStorage.setItem('fraudXrayCompleted', '1');
                 }
                 localStorage.setItem('fraudXrayFinished', '1');
-                if (!floaterRefocusDone) {
-                    bg.refocusTab();
-                    floaterRefocusDone = true;
-                }
+                // Always return focus to the original Fraud queue once DNA and
+                // search data are ready so the user sees the trial summary in
+                // the correct tab.
+                bg.refocusTab();
+                floaterRefocusDone = true;
                 trialFloater.ensure();
                 console.log('[FENNEC (POO)] Trial floater displayed');
                 const overlay = trialFloater.element;


### PR DESCRIPTION
## Summary
- make sure refocusing to the fraud queue always happens when showing the Trial Floater

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792b27a3b483269aeb1b2f0a03f7cf