### PR TITLE
Add keep flag to refocusTab

### DIFF
--- a/core/background_controller.js
+++ b/core/background_controller.js
@@ -110,10 +110,12 @@ class BackgroundController {
         if (sender.tab) chrome.tabs.remove(sender.tab.id);
     }
 
-    refocusTab() {
+    refocusTab(msg = {}) {
         chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
             if (fennecReturnTab) chrome.tabs.update(fennecReturnTab, { active: true });
-            chrome.storage.local.set({ fennecReturnTab: null });
+            if (!msg.keep) {
+                chrome.storage.local.set({ fennecReturnTab: null });
+            }
         });
     }
 }

--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -740,7 +740,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     if (chrome.runtime.lastError) {
                         console.error("[Copilot] Error focusing tab:", chrome.runtime.lastError.message);
                     }
-                    chrome.storage.local.set({ fennecReturnTab: null });
+                    if (!message.keep) {
+                        chrome.storage.local.set({ fennecReturnTab: null });
+                    }
                 });
             }
         });

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -561,7 +561,7 @@ class AdyenLauncher extends Launcher {
                     chrome.storage.local.get({ sidebarOrderInfo: null }, ({ sidebarOrderInfo }) => {
                         const email = sidebarOrderInfo ? sidebarOrderInfo.clientEmail : null;
                         bg.send('focusDbSearch', { email }, () => {
-                            bg.refocusTab();
+                            bg.refocusTab({ keep: true });
                         });
                     });
                 });

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -103,10 +103,10 @@ class KountLauncher extends Launcher {
                             if (fennecFraudAdyen) {
                                 chrome.storage.local.remove('fennecFraudAdyen');
                                 bg.openOrReuseTab({ url: fennecFraudAdyen, active: true }, () => {
-                                    bg.refocusTab();
+                                    bg.refocusTab({ keep: true });
                                 });
                             } else {
-                                bg.refocusTab();
+                                bg.refocusTab({ keep: true });
                             }
                         });
                     }, 1500);


### PR DESCRIPTION
## Summary
- allow `refocusTab` to optionally keep the stored tab ID
- keep the stored tab during early refocuses in Adyen and Kount flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879307c252c8326ba7fe48772abd9d7