### PR TITLE
Fix XRAY tab focus timing

### DIFF
--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -95,18 +95,11 @@ class KountLauncher extends Launcher {
                         const addressToName = findVal('Address to Name');
                         const residentName = findVal('Resident Name');
                         saveData({ ekata: { ipValid, proxyRisk, addressToName, residentName } });
-                        // Signal XRAY completion so the Trial floater can appear
-                        localStorage.setItem('fraudXrayFinished', '1');
-                        chrome.storage.local.set({ fraudXrayFinished: '1' });
                         sessionStorage.removeItem('fennecEkataUpdateClicked');
                         chrome.storage.local.get({ fennecFraudAdyen: null }, ({ fennecFraudAdyen }) => {
                             if (fennecFraudAdyen) {
                                 chrome.storage.local.remove('fennecFraudAdyen');
-                                bg.openOrReuseTab({ url: fennecFraudAdyen, active: true }, () => {
-                                    bg.refocusTab();
-                                });
-                            } else {
-                                bg.refocusTab();
+                                bg.openOrReuseTab({ url: fennecFraudAdyen, active: true });
                             }
                         });
                     }, 1500);


### PR DESCRIPTION
## Summary
- stop flagging `fraudXrayFinished` and refocusing the Fraud tab at the Ekata stage
- only open the Adyen DNA tab without switching back

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879329c138c83269ba6e7856816d4dd