### PR TITLE
Fix queue view summary refresh

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -608,8 +608,13 @@
         chrome.storage.onChanged.addListener((changes, area) => {
             if (area === 'local' && changes.fennecFraudOrders) {
                 fraudSet.clear();
-                (changes.fennecFraudOrders.newValue || []).forEach(id => fraudSet.add(String(id)));
+                (changes.fennecFraudOrders.newValue || []).forEach(id =>
+                    fraudSet.add(String(id))
+                );
                 highlightMatches();
+                // Refresh the summary so POSSIBLE FRAUD count includes the
+                // newly saved list once CSV orders have been injected.
+                updateSummary();
             }
         });
 


### PR DESCRIPTION
## Summary
- refresh Order Search queue summary after storing the fraud order list so the "POSSIBLE FRAUD" count updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793d4e2c288326a4066b9396287b7a