### PR TITLE
Fix Queue View summary totals and fraud flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ All notable changes to this project will be documented in this file.
 - Prevented Fraud Review tab from regaining focus when EKATA finishes during
   XRAY. Now the flow proceeds directly to Adyen without interrupting the
   current tab.
+- Queue View summary now shows totals from the downloaded CSV and flags orders
+  marked as Possible Fraud.

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -509,15 +509,21 @@
                     injectCsvOrders(orders);
 
                     const ids = orders.map(o => String(o.id));
-                    const flagged = ids.filter(id => fraudSet.has(id));
-                    console.log(`[FENNEC] Flagging ${flagged.length} possible fraud orders`);
-                    // Highlight all known fraud orders including the new matches
-                    highlightMatches(Array.from(fraudSet));
+                    const csvFraudIds = orders
+                        .filter(o => /possible fraud/i.test(o.status))
+                        .map(o => String(o.id));
+                    const flagged = ids.filter(id => fraudSet.has(id)).length;
+                    console.log(`[FENNEC] Flagging ${flagged + csvFraudIds.length} possible fraud orders`);
+                    // Highlight known fraud orders plus those marked as POSSIBLE FRAUD in the CSV
+                    const highlightIds = Array.from(new Set([...fraudSet, ...csvFraudIds]));
+                    highlightMatches(highlightIds);
+
+                    // Show the real totals again after all rows are injected
+                    showCsvSummary(orders);
 
                     // Re-enable summary updates now that injection is done
                     skipSummaryUpdate = false;
                     observeTable();
-                    updateSummary();
                 });
             });
         }


### PR DESCRIPTION
## Summary
- update summary from CSV after queue view table injection
- mark orders as possible fraud when CSV status includes it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793fb0d07883269f5aea907b34b239