### PR TITLE
Fix Queue View summary persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to this project will be documented in this file.
   current tab.
 - Queue View summary now shows totals from the downloaded CSV and flags orders
   marked as Possible Fraud.
+- Fixed CSV totals reverting after Queue View; summary now remains until run again.

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -526,9 +526,9 @@
                     // Show the real totals again after all rows are injected
                     showCsvSummary(orders);
 
-                    // Re-enable summary updates now that injection is done
-                    skipSummaryUpdate = false;
-                    observeTable();
+                    // Keep CSV totals displayed until Queue View runs again
+                    // so automatic updates don't revert the summary
+                    // skipSummaryUpdate remains true and table observer stays disabled
                 });
             });
         }


### PR DESCRIPTION
## Summary
- keep queue view totals shown after CSV injection
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794418233c83269cf765a6a596ff9b