### PR TITLE
Ensure fraud tracker focus after XRAY search

### DIFF
--- a/core/background_email_search.js
+++ b/core/background_email_search.js
@@ -735,13 +735,24 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.action === "dbEmailSearchResults" && sender.tab) {
         chrome.storage.local.get({ fennecDbSearchTab: null, fennecReturnTab: null }, data => {
-            if (data.fennecDbSearchTab === sender.tab.id && data.fennecReturnTab) {
-                chrome.tabs.update(data.fennecReturnTab, { active: true }, () => {
-                    if (chrome.runtime.lastError) {
-                        console.error("[Copilot] Error focusing tab:", chrome.runtime.lastError.message);
-                    }
-                    chrome.storage.local.set({ fennecDbSearchTab: null, fennecReturnTab: null });
-                });
+            const finalize = () => chrome.storage.local.set({ fennecDbSearchTab: null, fennecReturnTab: null });
+            if (data.fennecDbSearchTab === sender.tab.id) {
+                if (data.fennecReturnTab) {
+                    chrome.tabs.update(data.fennecReturnTab, { active: true }, () => {
+                        if (chrome.runtime.lastError) {
+                            console.error("[Copilot] Error focusing tab:", chrome.runtime.lastError.message);
+                        }
+                        finalize();
+                    });
+                } else {
+                    chrome.tabs.query({ url: "https://db.incfile.com/order-tracker/orders/fraud*" }, tabs => {
+                        const tab = tabs && tabs[0];
+                        if (tab) {
+                            chrome.tabs.update(tab.id, { active: true });
+                        }
+                        finalize();
+                    });
+                }
             }
         });
         return;


### PR DESCRIPTION
## Summary
- tweak dbEmailSearchResults handler to always return focus to fraud queue

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879458f25f483269e27cc541ba8510d