### PR TITLE
Fix fraud count in queue view

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -632,8 +632,8 @@
                 );
                 highlightMatches();
                 // Refresh the summary so POSSIBLE FRAUD count includes the
-                // newly saved list once CSV orders have been injected.
-                updateSummary();
+                // newly saved list even when automatic updates are disabled.
+                showCsvSummary(collectOrders());
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure queue view summary updates after collecting fraud orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687949dfcd0c83268e00e7427f0c2b1d