### PR TITLE
Fix final focus after Fraud Review XRAY

### DIFF
--- a/core/background_controller.js
+++ b/core/background_controller.js
@@ -112,8 +112,21 @@ class BackgroundController {
 
     refocusTab() {
         chrome.storage.local.get({ fennecReturnTab: null }, ({ fennecReturnTab }) => {
-            if (fennecReturnTab) chrome.tabs.update(fennecReturnTab, { active: true });
-            chrome.storage.local.set({ fennecReturnTab: null });
+            if (fennecReturnTab) {
+                chrome.tabs.update(fennecReturnTab, { active: true }, () => {
+                    if (chrome.runtime.lastError) {
+                        console.error('[Copilot] Error focusing tab:', chrome.runtime.lastError.message);
+                    }
+                    chrome.storage.local.set({ fennecReturnTab: null });
+                });
+            } else {
+                chrome.tabs.query({ url: 'https://db.incfile.com/order-tracker/orders/fraud*' }, tabs => {
+                    const tab = tabs && tabs[0];
+                    if (tab) {
+                        chrome.tabs.update(tab.id, { active: true });
+                    }
+                });
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- ensure `refocusTab` defaults to the fraud queue when the stored tab ID is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794adb12d48326b06e10e22ba90849