### PR TITLE
Fix CSV summary persistence in queue view

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -16,9 +16,9 @@
         let tableObserver = null;
         let skipSummaryUpdate = false;
         let lastCsvSummary = null;
-        if (sessionStorage.getItem('fennecCsvSummaryActive') === '1') {
+        if (localStorage.getItem('fennecCsvSummaryActive') === '1') {
             try {
-                lastCsvSummary = JSON.parse(sessionStorage.getItem('fennecCsvSummary'));
+                lastCsvSummary = JSON.parse(localStorage.getItem('fennecCsvSummary'));
                 if (lastCsvSummary) skipSummaryUpdate = true;
             } catch (e) {
                 lastCsvSummary = null;
@@ -410,8 +410,8 @@
             console.log(`[FENNEC] Rendering summary for ${total} CSV orders`);
             renderSummary(total, expCount, fraudCount, stateCounts, statusCounts, dateCounts);
             lastCsvSummary = { total, stateCounts, statusCounts, expCount, dateCounts, fraudCount };
-            sessionStorage.setItem('fennecCsvSummaryActive', '1');
-            sessionStorage.setItem('fennecCsvSummary', JSON.stringify(lastCsvSummary));
+            localStorage.setItem('fennecCsvSummaryActive', '1');
+            localStorage.setItem('fennecCsvSummary', JSON.stringify(lastCsvSummary));
         }
 
         function injectTableHelper() {
@@ -492,8 +492,8 @@
                 progress.style.display = 'block';
             }
             console.log('[FENNEC] Starting queue scan...');
-            sessionStorage.removeItem('fennecCsvSummary');
-            sessionStorage.removeItem('fennecCsvSummaryActive');
+            localStorage.removeItem('fennecCsvSummary');
+            localStorage.removeItem('fennecCsvSummaryActive');
             lastCsvSummary = null;
             if (icon) icon.classList.add('fennec-flash');
 


### PR DESCRIPTION
## Summary
- store queue view CSV summary in `localStorage`
- ensure summary survives page reloads until Queue View is clicked again

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68795fcacba88326a201684701803863