### PR TITLE
Fix Queue View summary reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to this project will be documented in this file.
 - Queue View summary now shows totals from the downloaded CSV and flags orders
   marked as Possible Fraud.
 - Fixed CSV totals reverting after Queue View; summary now remains until run again.
+- Queue View summary persists even if the page reloads during the scan.

--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -531,11 +531,8 @@
                 progress.style.display = 'block';
             }
             console.log('[FENNEC] Starting queue scan...');
-            sessionStorage.removeItem('fennecCsvSummary');
-            sessionStorage.removeItem('fennecCsvSummaryActive');
-            chrome.storage.local.remove(['fennecCsvSummary', 'fennecCsvSummaryActive']);
-            lastCsvSummary = null;
-            csvSummaryActive = false;
+            // Keep the previous summary in storage until the new CSV is processed
+            // so a page refresh doesn't wipe out the displayed totals.
             if (icon) icon.classList.add('fennec-flash');
 
             // Prevent automatic summary refreshes while the CSV is processed so


### PR DESCRIPTION
## Summary
- retain CSV summary when Queue View is running
- document fix in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879620115cc832689eec428304ff05e