### PR TITLE
Fix Queue View summary persistence

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -668,18 +668,24 @@
 
         function init() {
             injectSidebar();
-            if (lastCsvSummary) {
-                renderSummary(
-                    lastCsvSummary.total,
-                    lastCsvSummary.expCount,
-                    lastCsvSummary.fraudCount,
-                    lastCsvSummary.stateCounts,
-                    lastCsvSummary.statusCounts,
-                    lastCsvSummary.dateCounts
-                );
-            }
             waitForResults(() => {
-                updateSummary();
+                if (lastCsvSummary && csvSummaryActive) {
+                    const orders = collectOrders();
+                    if (orders.length === lastCsvSummary.total) {
+                        showCsvSummary(orders);
+                    } else {
+                        renderSummary(
+                            lastCsvSummary.total,
+                            lastCsvSummary.expCount,
+                            lastCsvSummary.fraudCount,
+                            lastCsvSummary.stateCounts,
+                            lastCsvSummary.statusCounts,
+                            lastCsvSummary.dateCounts
+                        );
+                    }
+                } else {
+                    updateSummary();
+                }
                 observeTable();
                 highlightMatches();
             });


### PR DESCRIPTION
## Summary
- keep Queue View totals after automatic refreshes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796451f24c83268a6f9a81fada6c77