### PR TITLE
Fix queue summary persistence

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -742,6 +742,19 @@
                 sendOrders();
             }
         });
+
+        // Persist CSV summary across page reloads so the sidebar does not
+        // revert to the initial state when the order search page refreshes.
+        window.addEventListener('beforeunload', () => {
+            if (csvSummaryActive && lastCsvSummary) {
+                sessionStorage.setItem('fennecCsvSummaryActive', '1');
+                sessionStorage.setItem('fennecCsvSummary', JSON.stringify(lastCsvSummary));
+                chrome.storage.local.set({
+                    fennecCsvSummaryActive: '1',
+                    fennecCsvSummary: JSON.stringify(lastCsvSummary)
+                });
+            }
+        });
     });
 })();
 


### PR DESCRIPTION
## Summary
- keep queue CSV totals after refresh by re-saving to storage on page unload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796451f24c83268a6f9a81fada6c77