### PR TITLE
Fix DataTables error and rename button

### DIFF
--- a/environments/db/db_order_search.js
+++ b/environments/db/db_order_search.js
@@ -647,7 +647,7 @@
                     </div>
                 </div>
                 <div class="copilot-body" id="copilot-body-content">
-                    <button id="queue-view-btn" class="copilot-button" style="width:100%;margin-bottom:8px">QUEUE VIEW</button>
+                    <button id="queue-view-btn" class="copilot-button" style="width:100%;margin-bottom:8px">VIEW ALL</button>
                     <div id="qs-summary" class="white-box" style="margin-bottom:10px"></div>
                     <div id="qs-progress" style="display:none;margin-bottom:10px;color:#ffa500;font-weight:bold"></div>
                 </div>`);

--- a/manifest.json
+++ b/manifest.json
@@ -109,6 +109,15 @@
       "matches": [
         "https://db.incfile.com/order-tracker/orders/order-search*"
       ],
+      "js": [
+        "environments/db/datatables_patch.js"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "https://db.incfile.com/order-tracker/orders/order-search*"
+      ],
       "all_frames": true,
       "js": [
         "core/utils.js",


### PR DESCRIPTION
## Summary
- inject DataTables patch early on order search pages to suppress ajax warnings
- rename `QUEUE VIEW` button to `VIEW ALL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796e2089e88326adf751bf196fd461