### PR TITLE
Fix DB order search DataTables warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@ All notable changes to this project will be documented in this file.
 - Fixed CSV totals reverting after Queue View; summary now remains until run again.
 - CSV orders and summary now persist across page refreshes so the table does not
   revert to the initial search results until Queue View is executed again.
+- Suppressed the DataTables Ajax warning on DB order search by loading the
+  datatables patch at document start.

--- a/manifest.json
+++ b/manifest.json
@@ -109,6 +109,14 @@
       "matches": [
         "https://db.incfile.com/order-tracker/orders/order-search*"
       ],
+      "js": ["environments/db/datatables_patch.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": [
+        "https://db.incfile.com/order-tracker/orders/order-search*"
+      ],
       "all_frames": true,
       "js": [
         "core/utils.js",


### PR DESCRIPTION
## Summary
- load the DataTables patch as a content script at document start
- note the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687971a3d5988326bf6f6e1fd8258cda