### PR TITLE
Fix DataTables Ajax alert

### DIFF
--- a/environments/db/datatables_patch.js
+++ b/environments/db/datatables_patch.js
@@ -4,13 +4,18 @@
     function setErrMode(){
         var jq = window.jQuery || window.$;
         if (jq && jq.fn && jq.fn.dataTable && jq.fn.dataTable.ext){
-            jq.fn.dataTable.ext.errMode = 'none';
+            jq.fn.dataTable.ext.errMode = function(){ /* no-op */ };
+            jq(document).on('error.dt', function(e){
+                e.preventDefault();
+            });
             return true;
         }
         return false;
     }
+
     function apply(){
         if (!setErrMode()) setTimeout(apply, 50);
     }
+
     apply();
 })();


### PR DESCRIPTION
## Summary
- intercept DataTables error events
- suppress global `errMode` handler to avoid alert popups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687975c3a1bc8326b44008422cbed72e