### PR TITLE
Add controls for DB order search sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,6 @@ All notable changes to this project will be documented in this file.
   revert to the initial search results until Queue View is executed again.
 - Suppressed the DataTables Ajax warning on DB order search by loading the
   datatables patch at document start.
+- DB Order Search sidebar now displays VIEW ALL, VIEW CURRENT and CLEAR buttons
+  below the summary box. VIEW CURRENT summarizes the visible page while CLEAR
+  resets stored CSV data.


### PR DESCRIPTION
## Summary
- move DB queue view button below the summary
- add VIEW CURRENT and CLEAR buttons
- implement functions to display current page summary and clear stored CSV data
- document the new buttons in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879b5429c1c8326baa77a074deb4139