### PR TITLE
Fix datatable column count for CSV injection

### DIFF
--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -14,7 +14,8 @@
                 return;
             }
             var table = $(tableEl).DataTable();
-            var colCount = $(tableEl).find('thead th').length;
+            // Use DataTables API to get the true column count including hidden columns
+            var colCount = table.columns().count();
             (e.data.rows || []).forEach(function(html){
                 var $row = $(html);
                 if (!$row.length) return;


### PR DESCRIPTION
## Summary
- fix injected table column count when inserting CSV rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879b9ca36b4832699d313d7d69ebf29