### PR TITLE
Fix CSV row injection column count

### DIFF
--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -19,7 +19,7 @@
                 return;
             }
             var table = $(tableEl).DataTable();
-            var colCount = $(tableEl).find('thead th').length;
+            var colCount = table.columns().count();
             (e.data.rows || []).forEach(function(html){
                 var $row = $(html);
                 if (!$row.length) return;


### PR DESCRIPTION
## Summary
- ensure table column count matches DataTables configuration when injecting rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a69d488c483269e603f734f709461