### PR TITLE
Fix DataTables row injection error

### DIFF
--- a/environments/db/table_inject.js
+++ b/environments/db/table_inject.js
@@ -27,7 +27,11 @@
                 for (var i = cells.length; i < colCount; i++) {
                     $row.append('<td></td>');
                 }
-                table.row.add($row[0]);
+                var data = [];
+                $row.children('td').each(function(){
+                    data.push(this.innerHTML);
+                });
+                table.row.add(data);
             });
             // Show all rows so injected orders are visible
             table.page.len(-1).draw(false);


### PR DESCRIPTION
## Summary
- avoid `_DT_CellIndex` error when injecting CSV rows into DB search results
- add rows via data arrays instead of raw DOM nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a6eb9fbcc8326b2b7c51886618cb1