### PR TITLE
Fix XRAY rerun when DB page refreshes

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -41,12 +41,9 @@ class DBLauncher extends Launcher {
         localStorage.removeItem('fraudXrayCompleted');
     }
     if (fraudXray && xrayDone) {
-        const params = new URLSearchParams(location.search);
-        params.delete('fraud_xray');
-        const newUrl = location.pathname + (params.toString() ? '?' + params.toString() : '');
-        history.replaceState(null, '', newUrl);
+        // Allow the XRAY flow to run again when manually refreshed by
+        // clearing the completion flag without stripping the parameter.
         localStorage.removeItem('fraudXrayCompleted');
-        fraudXray = false;
     }
 
     // Some DB pages do not show the correct LTV value until the order is

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -2042,6 +2042,10 @@ sbObj.build(`
                 : null;
             const dbUrl = `https://db.incfile.com/incfile/order/detail/${orderId}?fraud_xray=1`;
 
+            // Allow rerunning the XRAY flow even if a previous attempt
+            // stored a completion flag for this order.
+            localStorage.removeItem('fraudXrayCompleted');
+
             const data = {
                 fennecActiveSession: getFennecSessionId(),
                 fraudReviewSession: orderId,


### PR DESCRIPTION
## Summary
- ensure running the Gmail XRAY button clears any previous completion flag
- keep `fraud_xray=1` active on DB pages so Kount, Ekata and Adyen open after refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb0cbef84832697a3cac606c85b62