### PR TITLE
Fix XRAY flow after DB refresh

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -114,7 +114,9 @@ class DBLauncher extends Launcher {
                 if (typeof initQuickSummary === 'function') initQuickSummary();
                 attachCommonListeners(body);
                 updateReviewDisplay();
-                checkLastIssue(currentId);
+                if (typeof checkLastIssue === 'function') {
+                    checkLastIssue(currentId);
+                }
                 if (miscMode) {
                     setTimeout(autoOpenFamilyTree, 100);
                 }
@@ -1841,7 +1843,9 @@ class DBLauncher extends Launcher {
             attachCommonListeners(body);
             initMistralChat();
             updateReviewDisplay();
-            checkLastIssue(orderInfo.orderId);
+            if (typeof checkLastIssue === 'function') {
+                checkLastIssue(orderInfo.orderId);
+            }
             if (miscMode) {
                 setTimeout(autoOpenFamilyTree, 100);
             }
@@ -2113,6 +2117,7 @@ class DBLauncher extends Launcher {
             fillIssueBox(null, orderId);
         }
     }
+    window.checkLastIssue = checkLastIssue;
 
     function clearSidebar() {
         sessionSet({


### PR DESCRIPTION
## Summary
- guard call to `checkLastIssue` to avoid runtime error when reusing stored HTML
- expose `checkLastIssue` globally so asynchronous code can access it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687eb7542c4c832698c1bda9057e4da1