### PR TITLE
Fix Gmail XRAY DNA refresh

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1602,6 +1602,17 @@ sbObj.build(`
                 loadDnaSummary();
             loadKountSummary();
             }
+            if (area === 'local' && changes.fraudXrayFinished && changes.fraudXrayFinished.newValue === '1') {
+                chrome.storage.local.remove('fraudXrayFinished');
+                refreshSidebar();
+                const box = document.getElementById('issue-summary-box');
+                if (box) box.style.display = 'block';
+                ensureIssueControls(true);
+                updateDetailVisibility();
+                if (currentContext && currentContext.orderNumber) {
+                    checkLastIssue(currentContext.orderNumber);
+                }
+            }
             if (area === 'local' && changes.sidebarSnapshot && changes.sidebarSnapshot.newValue) {
                 const sb = document.getElementById('copilot-sidebar');
                 if (sb) {
@@ -1690,8 +1701,7 @@ sbObj.build(`
         // and show comment controls once XRAY completes.
         window.addEventListener('focus', () => {
             refreshSidebar();
-            if (localStorage.getItem('fraudXrayFinished') === '1') {
-                localStorage.removeItem('fraudXrayFinished');
+            const handleFinish = () => {
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);
@@ -1699,6 +1709,17 @@ sbObj.build(`
                 if (currentContext && currentContext.orderNumber) {
                     checkLastIssue(currentContext.orderNumber);
                 }
+            };
+            if (localStorage.getItem('fraudXrayFinished') === '1') {
+                localStorage.removeItem('fraudXrayFinished');
+                handleFinish();
+            } else {
+                chrome.storage.local.get({ fraudXrayFinished: null }, ({ fraudXrayFinished }) => {
+                    if (fraudXrayFinished === '1') {
+                        chrome.storage.local.remove('fraudXrayFinished');
+                        handleFinish();
+                    }
+                });
             }
         });
 


### PR DESCRIPTION
## Summary
- ensure Gmail sidebar refreshes ADYEN DNA box after XRAY
- watch `fraudXrayFinished` flag via chrome.storage
- check storage flag on focus to rebuild issue box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ef6accd048326b520f0ac5bd28743