### PR TITLE
Fix xray tab labels and summary order

### DIFF
--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -299,6 +299,16 @@ class AdyenLauncher extends Launcher {
                 return `<div class="section-label">ADYEN'S DNA</div><div class="white-box" style="margin-bottom:10px">${parts.join('')}</div>`;
             }
 
+            function insertDnaAfterCompany() {
+                const dnaBox = document.querySelector('.copilot-dna');
+                const compBox = document.querySelector('#copilot-sidebar .company-box');
+                if (!dnaBox || !compBox) return;
+                const parent = compBox.parentElement;
+                if (dnaBox.parentElement !== parent || dnaBox.previousElementSibling !== compBox) {
+                    parent.insertBefore(dnaBox, compBox.nextSibling);
+                }
+            }
+
             function loadDnaSummary() {
                 const container = document.getElementById('dna-summary');
                 if (!container) return;
@@ -309,6 +319,7 @@ class AdyenLauncher extends Launcher {
                         container.innerHTML = html || '';
                         attachCommonListeners(container);
                         if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
+                        insertDnaAfterCompany();
                     });
                 });
             }
@@ -327,6 +338,7 @@ class AdyenLauncher extends Launcher {
                             qbox.classList.remove('quick-summary-collapsed');
                             qbox.style.maxHeight = 'none';
                         }
+                        insertDnaAfterCompany();
                     } else {
                         container.innerHTML = '';
                         container.style.display = 'none';

--- a/environments/db/db_email_search.js
+++ b/environments/db/db_email_search.js
@@ -3,6 +3,7 @@
     const bg = fennecMessenger;
     chrome.storage.local.get({ extensionEnabled: true, fennecReviewMode: false }, ({ extensionEnabled, fennecReviewMode }) => {
         if (!extensionEnabled) return;
+        document.title = '[DB SEARCH] ' + document.title;
         const reviewMode = fennecReviewMode;
         const SIDEBAR_WIDTH = 340;
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -123,6 +123,7 @@ class DBLauncher extends Launcher {
                 if (typeof initQuickSummary === 'function') initQuickSummary();
                 attachCommonListeners(body);
                 updateReviewDisplay();
+                insertDnaAfterCompany();
                 if (typeof checkLastIssue === 'function') {
                     checkLastIssue(currentId);
                 }
@@ -1863,6 +1864,7 @@ class DBLauncher extends Launcher {
             body.innerHTML = html;
             if (typeof initQuickSummary === 'function') initQuickSummary();
             attachCommonListeners(body);
+            insertDnaAfterCompany();
             initMistralChat();
             updateReviewDisplay();
             if (typeof checkLastIssue === 'function') {
@@ -2051,6 +2053,7 @@ class DBLauncher extends Launcher {
             const html = buildDnaHtml(adyenDnaInfo);
             container.innerHTML = html || '';
             attachCommonListeners(container);
+            insertDnaAfterCompany();
         });
     }
 
@@ -2087,11 +2090,22 @@ class DBLauncher extends Launcher {
             const html = buildKountHtml(kountInfo);
             container.innerHTML = html || '';
             attachCommonListeners(container);
+            insertDnaAfterCompany();
         });
     }
 
     // Expose for other scripts
     window.loadKountSummary = loadKountSummary;
+
+    function insertDnaAfterCompany() {
+        const dnaBox = document.querySelector('.copilot-dna');
+        const compBox = document.querySelector('#copilot-sidebar .company-box');
+        if (!dnaBox || !compBox) return;
+        const parent = compBox.parentElement;
+        if (dnaBox.parentElement !== parent || dnaBox.previousElementSibling !== compBox) {
+            parent.insertBefore(dnaBox, compBox.nextSibling);
+        }
+    }
 
     function formatIssueText(text) {
         if (!text) return '';

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -851,6 +851,16 @@
             });
         }
 
+        function insertDnaAfterCompany() {
+            const dnaBox = document.querySelector('.copilot-dna');
+            const compBox = document.querySelector('#copilot-sidebar .company-box');
+            if (!dnaBox || !compBox) return;
+            const parent = compBox.parentElement;
+            if (dnaBox.parentElement !== parent || dnaBox.previousElementSibling !== compBox) {
+                parent.insertBefore(dnaBox, compBox.nextSibling);
+            }
+        }
+
         function repositionDnaSummary() {
             const dnaBox = document.querySelector('.copilot-dna');
             const summary = document.getElementById('dna-summary');
@@ -868,16 +878,7 @@
             if (kount && summary.nextSibling !== kount) {
                 dnaBox.insertBefore(kount, summary.nextSibling);
             }
-            const actionsRow = document.querySelector('#copilot-sidebar .copilot-actions');
-            if (reviewMode && actionsRow && dnaBox.previousElementSibling !== actionsRow) {
-                actionsRow.parentElement.insertBefore(dnaBox, actionsRow.nextSibling);
-            } else {
-                const compLabel = Array.from(document.querySelectorAll('#copilot-sidebar .section-label'))
-                    .find(el => el.textContent.trim().startsWith('COMPANY'));
-                if (compLabel && dnaBox.nextElementSibling !== compLabel) {
-                    compLabel.parentElement.insertBefore(dnaBox, compLabel);
-                }
-            }
+            insertDnaAfterCompany();
         }
 
         function buildTransactionTable(tx) {

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -12,6 +12,16 @@ class KountLauncher extends Launcher {
             if (label) label.style.display = reviewMode ? 'block' : 'none';
         }
 
+        function insertDnaAfterCompany() {
+            const dnaBox = document.querySelector('.copilot-dna');
+            const compBox = document.querySelector('#copilot-sidebar .company-box');
+            if (!dnaBox || !compBox) return;
+            const parent = compBox.parentElement;
+            if (dnaBox.parentElement !== parent || dnaBox.previousElementSibling !== compBox) {
+                parent.insertBefore(dnaBox, compBox.nextSibling);
+            }
+        }
+
 
 
         function injectSidebar() {
@@ -51,6 +61,7 @@ class KountLauncher extends Launcher {
                 sidebarBoxColor: '#2e2e2e'
             }, opts => applySidebarDesign(sb.element, opts));
             loadSidebarSnapshot(sb.element);
+            insertDnaAfterCompany();
             updateReviewDisplay();
 
             const closeBtn = sb.element.querySelector('#copilot-close');


### PR DESCRIPTION
## Summary
- tag DB email search tab for easier identification
- reorder DNA/Kount boxes after company summary across environments
- ensure DNA placement when loading stored summaries
- insert DNA after company for Adyen, DB, Gmail and Kount sidebars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd42f0bc08326958f92ec3b72c155