### PR TITLE
Fix Gmail DNA summary after XRAY

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1578,6 +1578,8 @@ sbObj.build(`
             if (area === 'local' && changes.fraudXrayFinished && changes.fraudXrayFinished.newValue === '1') {
                 chrome.storage.local.remove('fraudXrayFinished');
                 refreshSidebar();
+                loadDnaSummary();
+                loadKountSummary();
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);
@@ -1674,6 +1676,8 @@ sbObj.build(`
         // and show comment controls once XRAY completes.
         window.addEventListener('focus', () => {
             refreshSidebar();
+            loadDnaSummary();
+            loadKountSummary();
             const handleFinish = () => {
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';


### PR DESCRIPTION
## Summary
- ensure Gmail sidebar loads DNA and Kount data when XRAY finishes
- refresh DNA and Kount summaries whenever the Gmail tab regains focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe79c66288326bd7cdd141700edcf