### PR TITLE
Fix Gmail XRAY summaries

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1713,6 +1713,8 @@ sbObj.build(`
                 localStorage.removeItem('fraudXrayFinished');
                 ensureDnaSections();
                 refreshSidebar();
+                loadDnaSummary();
+                loadKountSummary();
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);


### PR DESCRIPTION
## Summary
- ensure Adyen DNA and Kount results load when XRAY finishes in Gmail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ff6ae1ce08326ad665d41fe3dd72d