### PR TITLE
Ensure active session restored before sidebar loads

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -30,13 +30,17 @@
         }
         try {
             const SIDEBAR_WIDTH = parseInt(sidebarWidth, 10) || 340;
-            getFennecSessionId();
-            let reviewMode = sessionStorage.getItem('fennecReviewMode');
-            reviewMode = reviewMode === null ? fennecReviewMode : reviewMode === 'true';
-            let currentContext = null;
-            let storedOrderInfo = null;
-            let droppedFiles = [];
-            let searchInProgress = false;
+            chrome.storage.local.get({ fennecActiveSession: null }, ({ fennecActiveSession }) => {
+                if (fennecActiveSession) {
+                    sessionStorage.setItem('fennecSessionId', fennecActiveSession);
+                }
+                getFennecSessionId();
+                let reviewMode = sessionStorage.getItem('fennecReviewMode');
+                reviewMode = reviewMode === null ? fennecReviewMode : reviewMode === 'true';
+                let currentContext = null;
+                let storedOrderInfo = null;
+                let droppedFiles = [];
+                let searchInProgress = false;
             const updateFloater = new UpdateFloater();
 
             function dedupeFiles(list) {
@@ -2102,6 +2106,7 @@ sbObj.build(`
             });
         }
 
+        }); // end fennecActiveSession get
 
     } catch (e) {
         console.error("[Copilot] ERROR en Gmail Launcher:", e);

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -2,8 +2,12 @@ class KountLauncher extends Launcher {
     init() {
     if (window.top !== window) return;
     const bg = fennecMessenger;
-    chrome.storage.local.get({ extensionEnabled: true, fennecReviewMode: false }, ({ extensionEnabled, fennecReviewMode }) => {
+    chrome.storage.local.get({ extensionEnabled: true, fennecReviewMode: false, fennecActiveSession: null }, ({ extensionEnabled, fennecReviewMode, fennecActiveSession }) => {
         if (!extensionEnabled) return;
+        if (fennecActiveSession) {
+            sessionStorage.setItem('fennecSessionId', fennecActiveSession);
+        }
+        getFennecSessionId();
         const reviewMode = fennecReviewMode;
         const SIDEBAR_WIDTH = 340;
 


### PR DESCRIPTION
## Summary
- set `fennecSessionId` from `chrome.storage.local` before initializing Gmail launcher
- do the same in Kount launcher

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ff579e9648326886ff9edf74f2327