### PR TITLE
Add family tree icon and quick summary toggle

### DIFF
--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -366,8 +366,12 @@ class AdyenLauncher extends Launcher {
                         if (isDnaPage) storeSidebarSnapshot(document.getElementById('copilot-sidebar'));
                         const qbox = container.querySelector('#quick-summary');
                         if (qbox) {
-                            qbox.classList.remove('quick-summary-collapsed');
-                            qbox.style.maxHeight = 'none';
+                            qbox.style.maxHeight = '0';
+                            qbox.classList.add('quick-summary-collapsed');
+                        }
+                        const ftIcon = document.getElementById('family-tree-icon');
+                        if (ftIcon) {
+                            ftIcon.style.display = container.querySelector('#family-tree-orders') ? 'inline' : 'none';
                         }
                         insertDnaAfterCompany();
                         if (typeof applyStandardSectionOrder === 'function') {
@@ -376,6 +380,8 @@ class AdyenLauncher extends Launcher {
                     } else {
                         container.innerHTML = '';
                         container.style.display = 'none';
+                        const ftIcon = document.getElementById('family-tree-icon');
+                        if (ftIcon) ftIcon.style.display = 'none';
                     }
                     if (typeof cb === 'function') cb();
                 });
@@ -462,7 +468,7 @@ class AdyenLauncher extends Launcher {
                 const sbObj = new Sidebar();
                 sbObj.build(`
                     ${buildSidebarHeader()}
-                    <div class="order-summary-header">ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
+                    <div class="order-summary-header"><span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span> ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
                     <div class="copilot-body">
                         <div class="copilot-dna">
                             <div id="dna-summary" style="margin-top:16px"></div>

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -794,8 +794,13 @@
                     attachCommonListeners(container);
                     const qbox = container.querySelector('#quick-summary');
                     if (qbox) {
-                        qbox.classList.remove('quick-summary-collapsed');
-                        qbox.style.maxHeight = 'none';
+                        qbox.style.maxHeight = '0';
+                        qbox.classList.add('quick-summary-collapsed');
+                    }
+                    const ftIcon = document.getElementById('family-tree-icon');
+                    if (ftIcon) {
+                        const type = (sidebarOrderInfo && sidebarOrderInfo.type) || '';
+                        ftIcon.style.display = /formation/i.test(type) ? 'none' : 'inline';
                     }
                     storedOrderInfo = sidebarOrderInfo;
                     fillOrderSummaryBox(currentContext);
@@ -803,6 +808,8 @@
                     container.innerHTML = '';
                     container.style.display = 'none';
                     storedOrderInfo = null;
+                    const ftIcon = document.getElementById('family-tree-icon');
+                    if (ftIcon) ftIcon.style.display = 'none';
                 }
 
 
@@ -1449,8 +1456,10 @@
 sbObj.build(`
                 ${buildSidebarHeader()}
                 <div class="order-summary-header">
+                    <span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span>
                     <button id="btn-xray" class="copilot-button">🩻 XRAY</button>
                     <button id="btn-email-search" class="copilot-button">📧 SEARCH</button>
+                    <span id="qs-toggle" class="quick-summary-toggle">⚡</span>
                 </div>
                 <div class="copilot-body">
                     <div class="copilot-dna">
@@ -1485,6 +1494,27 @@ sbObj.build(`
                 sidebarBoxColor: '#2e2e2e'
             }, opts => applySidebarDesign(sidebar, opts));
             loadSidebarSnapshot(sidebar, repositionDnaSummary);
+            const qsToggle = sidebar.querySelector('#qs-toggle');
+            const initQuickSummary = () => {
+                const box = sidebar.querySelector('#quick-summary');
+                if (!box) return;
+                box.style.maxHeight = '0';
+                box.classList.add('quick-summary-collapsed');
+            };
+            initQuickSummary();
+            if (qsToggle) {
+                qsToggle.addEventListener('click', () => {
+                    const box = sidebar.querySelector('#quick-summary');
+                    if (!box) return;
+                    if (box.style.maxHeight && box.style.maxHeight !== '0px') {
+                        box.style.maxHeight = '0';
+                        box.classList.add('quick-summary-collapsed');
+                    } else {
+                        box.classList.remove('quick-summary-collapsed');
+                        box.style.maxHeight = box.scrollHeight + 'px';
+                    }
+                });
+            }
 
             console.log("[Copilot] Sidebar INYECTADO en Gmail.");
 

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -182,8 +182,12 @@ class KountLauncher extends Launcher {
                     attachCommonListeners(container);
                     const qbox = container.querySelector('#quick-summary');
                     if (qbox) {
-                        qbox.classList.remove('quick-summary-collapsed');
-                        qbox.style.maxHeight = 'none';
+                        qbox.style.maxHeight = '0';
+                        qbox.classList.add('quick-summary-collapsed');
+                    }
+                    const ftIcon = document.getElementById('family-tree-icon');
+                    if (ftIcon) {
+                        ftIcon.style.display = container.querySelector('#family-tree-orders') ? 'inline' : 'none';
                     }
                     insertDnaAfterCompany();
                     if (typeof applyStandardSectionOrder === 'function') {
@@ -192,6 +196,8 @@ class KountLauncher extends Launcher {
                 } else {
                     container.innerHTML = '';
                     container.style.display = 'none';
+                    const ftIcon = document.getElementById('family-tree-icon');
+                    if (ftIcon) ftIcon.style.display = 'none';
                 }
                 if (typeof cb === 'function') cb();
             });
@@ -206,7 +212,7 @@ class KountLauncher extends Launcher {
             const sb = new Sidebar();
             sb.build(`
                 ${buildSidebarHeader()}
-                <div class="order-summary-header">ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
+                <div class="order-summary-header"><span id="family-tree-icon" class="family-tree-icon" style="display:none">🌳</span> ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
                 <div class="copilot-body" id="copilot-body-content">
                     <div id="db-summary-section"></div>
                     <div class="copilot-dna">


### PR DESCRIPTION
## Summary
- add family tree icon and quick summary toggle to Gmail sidebar
- collapse quick summary by default in Gmail
- show family tree icon depending on stored order info
- add family tree icon to Kount and Adyen sidebars
- collapse quick summary by default when loading stored data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880fdb646c483268d8ea520ea66efe1