### PR TITLE
Unify sidebar injection

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -81,6 +81,79 @@ function buildStandardSidebarHTML(opts = {}) {
 }
 window.buildStandardSidebarHTML = buildStandardSidebarHTML;
 
+function injectStandardSidebar(opts = {}, cb) {
+    const {
+        width = 340,
+        devMode = false,
+        includeOrderBox = false,
+        bodyId = 'copilot-body-content',
+        includeXray = false,
+        includeSearch = false
+    } = opts;
+    if (document.getElementById('copilot-sidebar')) {
+        if (typeof cb === 'function') cb(document.getElementById('copilot-sidebar'));
+        return document.getElementById('copilot-sidebar');
+    }
+    if (width) {
+        document.body.style.transition = 'margin-right 0.2s';
+        document.body.style.marginRight = width + 'px';
+    }
+    const sb = new Sidebar();
+    sb.build(buildStandardSidebarHTML({ devMode, includeOrderBox, bodyId, includeXray, includeSearch }));
+    sb.attach();
+    const sidebar = sb.element;
+    chrome.storage.sync.get({
+        sidebarFontSize: 13,
+        sidebarFont: "'Inter', sans-serif",
+        sidebarBgColor: '#212121',
+        sidebarBoxColor: '#2e2e2e'
+    }, opts => applySidebarDesign(sidebar, opts));
+    loadSidebarSnapshot(sidebar, () => {
+        if (typeof insertDnaAfterCompany === 'function') insertDnaAfterCompany();
+        if (typeof applyStandardSectionOrder === 'function') applyStandardSectionOrder(sidebar.querySelector('#db-summary-section'));
+        if (typeof cb === 'function') cb(sidebar);
+    });
+    const qsToggle = sidebar.querySelector('#qs-toggle');
+    if (qsToggle) {
+        const init = () => {
+            const box = sidebar.querySelector('#quick-summary');
+            if (!box) return;
+            box.style.maxHeight = '0';
+            box.classList.add('quick-summary-collapsed');
+        };
+        init();
+        qsToggle.addEventListener('click', () => {
+            const box = sidebar.querySelector('#quick-summary');
+            if (!box) return;
+            if (box.style.maxHeight && box.style.maxHeight !== '0px') {
+                box.style.maxHeight = '0';
+                box.classList.add('quick-summary-collapsed');
+            } else {
+                box.classList.remove('quick-summary-collapsed');
+                box.style.maxHeight = box.scrollHeight + 'px';
+            }
+        });
+    }
+    const closeBtn = sidebar.querySelector('#copilot-close');
+    if (closeBtn) closeBtn.onclick = () => {
+        sb.remove();
+        document.body.style.marginRight = '';
+    };
+    const clearTabsBtn = sidebar.querySelector('#copilot-clear-tabs');
+    if (clearTabsBtn && typeof fennecMessenger !== 'undefined') clearTabsBtn.onclick = () => fennecMessenger.closeOtherTabs();
+    const clearSb = sidebar.querySelector('#copilot-clear');
+    if (clearSb) clearSb.onclick = () => {
+        sidebar.querySelector('#db-summary-section').innerHTML = '';
+        const d = sidebar.querySelector('#dna-summary');
+        if (d) d.innerHTML = '';
+        const k = sidebar.querySelector('#kount-summary');
+        if (k) k.innerHTML = '';
+        sessionSet({ sidebarDb: [], adyenDnaInfo: null, kountInfo: null });
+    };
+    return sidebar;
+}
+window.injectStandardSidebar = injectStandardSidebar;
+
 function getFennecSessionId() {
     let id = sessionStorage.getItem('fennecSessionId');
     if (!id) {

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -465,23 +465,7 @@ class AdyenLauncher extends Launcher {
 
             function injectSidebar() {
                 if (document.getElementById('copilot-sidebar')) return;
-                const sbObj = new Sidebar();
-                sbObj.build(buildStandardSidebarHTML());
-                sbObj.attach();
-                const sidebar = sbObj.element;
-                chrome.storage.sync.get({
-                    sidebarFontSize: 13,
-                    sidebarFont: "'Inter', sans-serif",
-                    sidebarBgColor: '#212121',
-                    sidebarBoxColor: '#2e2e2e'
-                }, opts => applySidebarDesign(sidebar, opts));
-                loadSidebarSnapshot(sidebar, () => {
-                    insertDnaAfterCompany();
-                    if (typeof applyStandardSectionOrder === 'function') {
-                        applyStandardSectionOrder(sidebar.querySelector('#db-summary-section'));
-                    }
-                });
-                document.body.style.marginRight = '340px';
+                const sidebar = injectStandardSidebar({ width: 340 });
                 const qsToggle = sidebar.querySelector('#qs-toggle');
                 if (qsToggle) {
                     const initQuickSummary = () => {
@@ -505,15 +489,10 @@ class AdyenLauncher extends Launcher {
                 }
                 const closeBtn = sidebar.querySelector('#copilot-close');
                 if (closeBtn) {
+                    const orig = closeBtn.onclick;
                     closeBtn.onclick = () => {
-                        sidebar.remove();
+                        if (typeof orig === 'function') orig();
                         document.body.style.marginRight = '';
-                    };
-                }
-                const clearTabsBtn = sidebar.querySelector('#copilot-clear-tabs');
-                if (clearTabsBtn) {
-                    clearTabsBtn.onclick = () => {
-                        bg.closeOtherTabs();
                     };
                 }
                 const clearSb = sidebar.querySelector('#copilot-clear');

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -506,38 +506,25 @@ class DBLauncher extends Launcher {
 
                 (function injectSidebar() {
                     if (document.getElementById('copilot-sidebar')) return;
-                    const sbObj = new Sidebar();
-                    sbObj.build(buildStandardSidebarHTML({ devMode, bodyId: 'copilot-body-content' }));
-                    sbObj.attach();
-                    const sidebar = sbObj.element;
+                    const sidebar = injectStandardSidebar({
+                        width: SIDEBAR_WIDTH,
+                        devMode,
+                        bodyId: 'copilot-body-content'
+                    });
                     const dbSec = sidebar.querySelector('#db-summary-section');
                     if (dbSec) {
                         dbSec.innerHTML = '<div style="text-align:center; color:#888; margin-top:20px">Cargando resumen...</div>';
                     }
-                    chrome.storage.sync.get({
-                        sidebarFontSize: 13,
-                        sidebarFont: "'Inter', sans-serif",
-                        sidebarBgColor: '#212121',
-                        sidebarBoxColor: '#2e2e2e'
-                    }, opts => applySidebarDesign(sidebar, opts));
-                    loadSidebarSnapshot(sidebar, updateReviewDisplay);
                     const closeBtn = sidebar.querySelector('#copilot-close');
                     if (closeBtn) {
+                        const orig = closeBtn.onclick;
                         closeBtn.onclick = () => {
-                            sidebar.remove();
-                            document.body.style.marginRight = '';
+                            if (typeof orig === 'function') orig();
                             const style = document.getElementById('copilot-db-padding');
                             if (style) style.remove();
                             sessionStorage.setItem("fennecSidebarClosed", "true");
                             console.log("[FENNEC (POO)] Sidebar cerrado manualmente en DB.");
                             showFloatingIcon();
-                        };
-                    }
-
-                    const clearBtn = sidebar.querySelector('#copilot-clear-tabs');
-                    if (clearBtn) {
-                        clearBtn.onclick = () => {
-                            bg.closeOtherTabs();
                         };
                     }
                     const clearSb = sidebar.querySelector('#copilot-clear');

--- a/environments/kount/kount_launcher.js
+++ b/environments/kount/kount_launcher.js
@@ -207,22 +207,7 @@ class KountLauncher extends Launcher {
 
         function injectSidebar() {
             if (document.getElementById('copilot-sidebar')) return;
-            document.body.style.transition = 'margin-right 0.2s';
-            document.body.style.marginRight = SIDEBAR_WIDTH + 'px';
-            const sb = new Sidebar();
-            sb.build(buildStandardSidebarHTML({ bodyId: 'copilot-body-content' }));
-            sb.attach();
-            chrome.storage.sync.get({
-                sidebarFontSize: 13,
-                sidebarFont: "'Inter', sans-serif",
-                sidebarBgColor: '#212121',
-                sidebarBoxColor: '#2e2e2e'
-            }, opts => applySidebarDesign(sb.element, opts));
-            loadSidebarSnapshot(sb.element, () => {
-                insertDnaAfterCompany();
-                if (typeof applyStandardSectionOrder === 'function') {
-                    applyStandardSectionOrder(sb.element.querySelector('#db-summary-section'));
-                }
+            const sidebar = injectStandardSidebar({ width: SIDEBAR_WIDTH, bodyId: 'copilot-body-content' }, () => {
                 loadDbSummary(() => {
                     loadDnaSummary(() => {
                         loadKountSummary(updateReviewDisplay);
@@ -230,17 +215,17 @@ class KountLauncher extends Launcher {
                 });
             });
 
-            const qsToggle = sb.element.querySelector('#qs-toggle');
+            const qsToggle = sidebar.querySelector('#qs-toggle');
             if (qsToggle) {
                 const initQuickSummary = () => {
-                    const box = sb.element.querySelector('#quick-summary');
+                    const box = sidebar.querySelector('#quick-summary');
                     if (!box) return;
                     box.style.maxHeight = '0';
                     box.classList.add('quick-summary-collapsed');
                 };
                 initQuickSummary();
                 qsToggle.addEventListener('click', () => {
-                    const box = sb.element.querySelector('#quick-summary');
+                    const box = sidebar.querySelector('#quick-summary');
                     if (!box) return;
                     if (box.style.maxHeight && box.style.maxHeight !== '0px') {
                         box.style.maxHeight = '0';
@@ -252,18 +237,21 @@ class KountLauncher extends Launcher {
                 });
             }
 
-            const closeBtn = sb.element.querySelector('#copilot-close');
-            if (closeBtn) closeBtn.onclick = () => {
-                sb.remove();
-                document.body.style.marginRight = '';
-            };
-            const clearTabsBtn = sb.element.querySelector('#copilot-clear-tabs');
+            const closeBtn = sidebar.querySelector('#copilot-close');
+            if (closeBtn) {
+                const orig = closeBtn.onclick;
+                closeBtn.onclick = () => {
+                    if (typeof orig === 'function') orig();
+                    document.body.style.marginRight = '';
+                };
+            }
+            const clearTabsBtn = sidebar.querySelector('#copilot-clear-tabs');
             if (clearTabsBtn) clearTabsBtn.onclick = () => bg.closeOtherTabs();
-            const clearSb = sb.element.querySelector('#copilot-clear');
+            const clearSb = sidebar.querySelector('#copilot-clear');
             if (clearSb) clearSb.onclick = () => {
-                sb.element.querySelector('#db-summary-section').innerHTML = '';
-                sb.element.querySelector('#dna-summary').innerHTML = '';
-                sb.element.querySelector('#kount-summary').innerHTML = '';
+                sidebar.querySelector('#db-summary-section').innerHTML = '';
+                sidebar.querySelector('#dna-summary').innerHTML = '';
+                sidebar.querySelector('#kount-summary').innerHTML = '';
                 sessionSet({ sidebarDb: [], adyenDnaInfo: null, kountInfo: null });
             };
         }


### PR DESCRIPTION
## Summary
- add `injectStandardSidebar` helper to consolidate sidebar setup
- simplify DB, Adyen and Kount launchers to use the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811b72cd848326bfdbb05a7b2d81c5