### PR TITLE
Fix Gmail sidebar DNA summary

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1071,6 +1071,7 @@
         }
 
         function loadDnaSummary() {
+            ensureDnaSections();
             const container = document.getElementById('dna-summary');
             if (!container) return;
             console.log('[Copilot] Loading DNA summary');
@@ -1095,6 +1096,7 @@
         }
 
         function loadKountSummary() {
+            ensureDnaSections();
             const container = document.getElementById('kount-summary');
             if (!container) return;
             chrome.storage.local.get({ kountInfo: null }, ({ kountInfo }) => {
@@ -1173,7 +1175,7 @@
             const afterBtn = xrayBtn || dnaBtn;
             if (afterBtn) dnaBox.insertBefore(summary, afterBtn.nextSibling); else dnaBox.appendChild(summary);
             summary.innerHTML = `<img src="${chrome.runtime.getURL('fennec_icon.png')}" class="loading-fennec"/>`;
-            sessionSet({ adyenDnaInfo: null });
+            // Keep any previously stored DNA data until new info arrives
             repositionDnaSummary();
         }
 
@@ -1237,7 +1239,7 @@
                 if (summary) summary.innerHTML = '';
                 const kount = dnaBox.querySelector('#kount-summary');
                 if (kount) kount.innerHTML = '';
-                sessionSet({ adyenDnaInfo: null, kountInfo: null });
+                // Do not clear stored DNA/Kount info so summaries reappear when available
                 repositionDnaSummary();
             }
         if (issueLabel) {
@@ -1416,8 +1418,6 @@
                 Object.assign(data, {
                     fraudReviewSession: null,
                     sidebarFreezeId: null,
-                    adyenDnaInfo: null,
-                    kountInfo: null,
                     fennecFraudAdyen: null
                 });
             } else if (orderId) {
@@ -1426,9 +1426,7 @@
                     sidebarFreezeId: orderId,
                     sidebarDb: [],
                     sidebarOrderId: null,
-                    sidebarOrderInfo: null,
-                    adyenDnaInfo: null,
-                    kountInfo: null
+                    sidebarOrderInfo: null
                 });
                 sessionStorage.setItem('fennecShowTrialFloater', '1');
                 localStorage.removeItem('fraudXrayFinished');
@@ -2070,9 +2068,7 @@ sbObj.build(`
                 sidebarFreezeId: orderId,
                 sidebarDb: [],
                 sidebarOrderId: null,
-                sidebarOrderInfo: null,
-                adyenDnaInfo: null,
-                kountInfo: null
+                sidebarOrderInfo: null
             };
             sessionStorage.setItem('fennecShowTrialFloater', '1');
             localStorage.removeItem('fraudXrayFinished');


### PR DESCRIPTION
## Summary
- retain stored Adyen DNA and Kount data when launching XRAY
- always ensure DNA sections exist when loading summaries
- stop clearing DNA and Kount info during XRAY setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811f6dc8748326a74b11120ab137c3