### PR TITLE
Ensure Gmail sidebar refreshes DNA info

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1313,6 +1313,9 @@
             }
             if (dnaSummary) dnaSummary.innerHTML = '';
             if (kountSummary) kountSummary.innerHTML = '';
+            ensureDnaSections();
+            loadDnaSummary();
+            loadKountSummary();
             repositionDnaSummary();
         }
 


### PR DESCRIPTION
## Summary
- load DNA and Kount summaries whenever the sidebar resets in Gmail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811f6dc8748326a74b11120ab137c3