### PR TITLE
Fix Gmail XRAY DNA display

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -22,6 +22,19 @@
             return;
         }
         document.title = '[GM] ' + document.title;
+        function maintainTitle(prefix) {
+            const t = `[${prefix}] `;
+            const titleEl = document.querySelector('title');
+            if (!titleEl) return;
+            const apply = () => {
+                if (!document.title.startsWith(t)) {
+                    document.title = t + document.title.replace(/^\[[^\]]+\]\s*/, '');
+                }
+            };
+            new MutationObserver(apply).observe(titleEl, { childList: true });
+            apply();
+        }
+        maintainTitle('GM');
         if (lightMode) {
             document.body.classList.add('fennec-light-mode');
         } else {
@@ -1583,6 +1596,7 @@ sbObj.build(`
                 refreshSidebar();
                 loadDnaSummary();
                 loadKountSummary();
+                startDnaWatch();
                 const box = document.getElementById('issue-summary-box');
                 if (box) box.style.display = 'block';
                 ensureIssueControls(true);


### PR DESCRIPTION
## Summary
- ensure Gmail tab title keeps `[GM]` prefix via mutation observer
- restart DNA polling when XRAY completes in Gmail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813feb7f788326be6fd1d379143429