### PR TITLE
Fix Gmail sidebar session updates

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1334,9 +1334,10 @@
             if (kountSummary) kountSummary.innerHTML = '';
             console.log('[Copilot] cleared ADYEN DNA/KOUNT summaries');
             ensureDnaSections();
-            loadDnaSummary();
-            loadKountSummary();
-            repositionDnaSummary();
+            if (dnaWatchInterval) {
+                clearInterval(dnaWatchInterval);
+                dnaWatchInterval = null;
+            }
         }
 
         function refreshSidebar() {
@@ -1507,10 +1508,6 @@ sbObj.build(`
 
             // Start with empty layout showing only action buttons.
             showInitialStatus();
-            loadDnaSummary();
-            loadKountSummary();
-            repositionDnaSummary();
-            startDnaWatch();
             // Details load after the user interacts with SEARCH or when
             // opened automatically with context.
 


### PR DESCRIPTION
## Summary
- clear DNA/Kount watchers when resetting Gmail sidebar
- avoid auto-loading DNA/Kount on sidebar injection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881563fbe8083269712236b2dd6052d