### PR TITLE
Fix Gmail sidebar review mode reset

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1355,10 +1355,15 @@
             }
         }
 
-        function refreshSidebar() {
+       function refreshSidebar() {
             const ctx = extractOrderContextFromEmail();
             currentContext = ctx;
             chrome.storage.local.get({ sidebarFreezeId: null }, ({ sidebarFreezeId }) => {
+                const prevId = sidebarFreezeId || (storedOrderInfo && storedOrderInfo.orderId);
+                if (ctx && prevId && ctx.orderNumber !== prevId) {
+                    clearSidebar();
+                    return;
+                }
                 if (ctx && sidebarFreezeId && ctx.orderNumber !== sidebarFreezeId) {
                     sessionSet({ sidebarFreezeId: null, adyenDnaInfo: null });
                 }
@@ -1392,6 +1397,7 @@
                 fennecFraudAdyen: null,
                 sidebarSnapshot: null
             });
+            localStorage.removeItem('fraudXrayFinished');
             showInitialStatus();
             applyReviewMode();
             loadDnaSummary();


### PR DESCRIPTION
## Summary
- ensure Gmail sidebar clears previous order data when switching emails
- reset sidebar UI and extension storage on clear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815ea3a868832689db29586e84426e