### PR TITLE
Fix Gmail review session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@ All notable changes to this project will be documented in this file.
 - Quick Actions EMAILS option now opens a Gmail search instead of the DB email search.
 - Fixed Review Mode sidebar not clearing after closing the email tab; session data now resets when leaving Gmail.
 - Fixed Gmail sidebar leaving Kount info after closing the email; storage now fully resets.
+- Fixed Gmail Review Mode showing old issue data when returning to Inbox or opening a new email; session storage now clears on pagehide.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -5,7 +5,7 @@
     const bg = fennecMessenger;
     // Clear the closed flag on reload and wipe session data on unload so
     // old details don't persist when returning to Gmail.
-    window.addEventListener('beforeunload', () => {
+    function cleanupSidebarSession() {
         sessionStorage.removeItem("fennecSidebarClosed");
         sessionSet({
             sidebarDb: [],
@@ -21,7 +21,10 @@
         });
         sessionStorage.removeItem('fennecShowTrialFloater');
         localStorage.removeItem('fraudXrayFinished');
-    });
+    }
+
+    window.addEventListener('beforeunload', cleanupSidebarSession);
+    window.addEventListener('pagehide', cleanupSidebarSession);
     chrome.runtime.onMessage.addListener((msg) => {
         if (msg.action === 'fennecToggle') {
             window.location.reload();


### PR DESCRIPTION
## Summary
- ensure Gmail sidebar state clears on pagehide
- document fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881678f51108326b75339219c212b85