### PR TITLE
Fix Gmail inbox sidebar cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@ All notable changes to this project will be documented in this file.
 - Fixed Review Mode sidebar not clearing after closing the email tab; session data now resets when leaving Gmail.
 - Fixed Gmail sidebar leaving Kount info after closing the email; storage now fully resets.
 - Fixed Gmail Review Mode showing old issue data when returning to Inbox or opening a new email; session storage now clears on pagehide.
+- Fixed Gmail inbox not clearing stored order issues; the sidebar now resets when loading `#inbox`.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -7,7 +7,7 @@
     // old details don't persist when returning to Gmail.
     function cleanupSidebarSession() {
         sessionStorage.removeItem("fennecSidebarClosed");
-        sessionSet({
+        const data = {
             sidebarDb: [],
             sidebarOrderId: null,
             sidebarOrderInfo: null,
@@ -18,16 +18,21 @@
             forceFraudXray: null,
             fennecFraudAdyen: null,
             sidebarSnapshot: null
-        });
+        };
+        sessionSet(data);
         sessionStorage.removeItem('fennecShowTrialFloater');
         localStorage.removeItem('fraudXrayFinished');
-        chrome.storage.local.remove([
+        chrome.storage.local.remove(Object.keys(data).concat([
             'fennecPendingComment',
             'fennecPendingUpload',
             'fennecUpdateRequest',
             'fennecQuickResolveDone',
             'fennecUploadDone'
-        ]);
+        ]));
+    }
+
+    if (window.location.hash.startsWith('#inbox')) {
+        cleanupSidebarSession();
     }
 
     window.addEventListener('beforeunload', cleanupSidebarSession);


### PR DESCRIPTION
## Summary
- clear saved sidebar state when Gmail loads the `#inbox` route
- remove extension storage values when cleaning the Gmail sidebar session
- document fix in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68827701bfc8832680fa60c0f454bd15