### PR TITLE
Ensure Gmail searches use correct account

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For FRAUD REVIEW (XRAY icon)
 
 For ID CONFIRM (XRAY button) 
 8. Activate the original GM, where button is originally clicked:
-   https://mail.google.com/mail/?authuser=efile1234@incfile.com#inbox/* or related.
+   https://mail.google.com/mail/u/efile1234@incfile.com/#inbox/* or related.
 
 At the end of both flows, all tabs included in the flow must be properly identified, and the SB injected with proper padding in all. The SB once the XRAY is completed should be constructed as desinged in REVIEW MODE.
 
@@ -230,7 +230,7 @@ For FRAUD REVIEW (XRAY icon)
 
 For ID CONFIRM (XRAY button) 
 8. Activate the original GM, where button is originally clicked:
-   https://mail.google.com/mail/?authuser=efile1234@incfile.com#inbox/* or related.
+   https://mail.google.com/mail/u/efile1234@incfile.com/#inbox/* or related.
 
 At the end of both flows, all tabs included in the flow must be properly identified, and the SB injected with proper padding in all. The SB once the XRAY is completed should be constructed as desinged in REVIEW MODE.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -680,7 +680,7 @@ class DBLauncher extends Launcher {
                             if (parts.length) {
                                 const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
                                 const url =
-                                    'https://mail.google.com/mail/?authuser=efile1234@incfile.com#search/' +
+                                    'https://mail.google.com/mail/u/efile1234@incfile.com/#search/' +
                                     query;
                                 bg.openActiveTab({ url });
                             }
@@ -2914,7 +2914,7 @@ function getLastHoldUser() {
         if (!client.email && parts.length) {
             const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
             const gmailUrl =
-                'https://mail.google.com/mail/?authuser=efile1234@incfile.com#search/' +
+                'https://mail.google.com/mail/u/efile1234@incfile.com/#search/' +
                 query;
             bg.openOrReuseTab({ url: gmailUrl, active: true });
         }

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1467,7 +1467,7 @@
 
             const finalQuery = queryParts.join(" OR ");
             const gmailSearchUrl =
-                `https://mail.google.com/mail/?authuser=efile1234@incfile.com#search/${encodeURIComponent(finalQuery)}`;
+                `https://mail.google.com/mail/u/efile1234@incfile.com/#search/${encodeURIComponent(finalQuery)}`;
 
             const urls = [gmailSearchUrl];
 


### PR DESCRIPTION
## Summary
- update Gmail search URLs to explicitly use the efile account
- adjust README documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68827db7e62c83268ee5539df579d47f