### PR TITLE
Add rename fields for uploads

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -2349,7 +2349,8 @@ class DBLauncher extends Launcher {
         chrome.storage.local.remove('fennecPendingUpload');
         const token = document.querySelector('meta[name="csrf-token"]');
         const csrf = token ? token.getAttribute('content') : '';
-        const files = Array.isArray(data.files) ? data.files : [{ fileName: data.fileName, fileData: data.fileData }];
+        const files = Array.isArray(data.files) ? data.files
+            : [{ fileName: data.fileName, fileData: data.fileData, origName: data.origName, converted: data.converted }];
         const uploadNext = () => {
             if (!files.length) {
                 if (data.comment || data.release) {
@@ -2368,7 +2369,7 @@ class DBLauncher extends Launcher {
                     credentials: 'include'
                 });
             }).then(() => {
-                sessionSet({ fennecUploadDone: { time: Date.now() } }, uploadNext);
+                sessionSet({ fennecUploadDone: { time: Date.now(), fileName: file.fileName, origName: file.origName, converted: !!file.converted } }, uploadNext);
             }).catch(err => { console.warn('[FENNEC (POO)] Upload failed:', err); uploadNext(); });
         };
         uploadNext();

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -216,6 +216,23 @@
     font-size: 12px;
 }
 
+.dropped-file-row {
+    display: flex;
+    align-items: center;
+    margin: 4px;
+}
+
+.dropped-file-name {
+    flex: 1;
+    margin-left: 4px;
+    padding: 2px;
+    font-size: 12px;
+    border: 1px solid #888;
+    border-radius: 4px;
+    background: #fff;
+    color: #000;
+}
+
 
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -393,6 +393,23 @@
     color: #0a0;
 }
 
+.fennec-light-mode .dropped-file-row {
+    display: flex;
+    align-items: center;
+    margin: 4px;
+}
+
+.fennec-light-mode .dropped-file-name {
+    flex: 1;
+    margin-left: 4px;
+    padding: 2px;
+    font-size: 12px;
+    border: 1px solid #777;
+    border-radius: 4px;
+    background: #fff;
+    color: #000;
+}
+
 
 .fennec-light-mode #fennec-trial-overlay .name-match {
     margin-left: 4px;


### PR DESCRIPTION
## Summary
- show each dropped file with a rename input field
- adjust button text depending on PDF status
- carry rename info through conversion and upload
- indicate rename in upload confirmation message
- style rename inputs for dark and light modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882f1464f208326b6f1f15b90137a42