### PR TITLE
Fix email search focus and upload naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ All notable changes to this project will be documented in this file.
 - Fixed Gmail Review Mode showing old issue data when returning to Inbox or opening a new email; session storage now clears on pagehide.
 - Fixed Gmail inbox not clearing stored order issues; the sidebar now resets when loading `#inbox`.
 - Gmail email search now switches to the delegated account automatically before submitting the query.
+- Fixed Gmail EMAIL SEARCH button leaving focus on search results and failing to build the sidebar summaries.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1568,7 +1568,7 @@
                 localStorage.removeItem('fraudXrayFinished');
             }
             sessionSet(data, () => {
-                bg.replaceTabs({ urls, refocus: xray, activeFirst: true });
+                bg.replaceTabs({ urls, refocus: true, activeFirst: false });
                 setTimeout(() => { searchInProgress = false; }, 1000);
             });
             if (orderId) {
@@ -1895,8 +1895,11 @@ sbObj.build(`
                 icon.textContent = `📎 ${item.file.name}`;
                 const input = document.createElement('input');
                 input.className = 'dropped-file-name';
-                input.value = item.name;
-                input.addEventListener('input', e => item.name = e.target.value);
+                input.placeholder = '[CHANGE NAME]';
+                if (item.name !== item.file.name) input.value = item.name;
+                input.addEventListener('input', e => {
+                    item.name = e.target.value.trim() || item.file.name;
+                });
                 row.appendChild(icon);
                 row.appendChild(input);
                 list.appendChild(row);

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -233,6 +233,11 @@
     color: #000;
 }
 
+.dropped-file-name::placeholder {
+    color: #888;
+    opacity: 1;
+}
+
 
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -410,6 +410,11 @@
     color: #000;
 }
 
+.fennec-light-mode .dropped-file-name::placeholder {
+    color: #777;
+    opacity: 1;
+}
+
 
 .fennec-light-mode #fennec-trial-overlay .name-match {
     margin-left: 4px;


### PR DESCRIPTION
## Summary
- keep focus on the original Gmail tab when using EMAIL SEARCH
- allow renaming dropped files and show placeholder
- style placeholder text for dark and light modes
- note Gmail EMAIL SEARCH fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68839fc4086c832686058a27ee4ff268