### PR TITLE
Fix Gmail sidebar persistence on search

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -896,10 +896,12 @@
                     }
                     storedOrderInfo = sidebarOrderInfo;
                     fillOrderSummaryBox(currentContext);
-                } else {
+                } else if (container.innerHTML.trim() === '') {
                     container.innerHTML = '';
                     container.style.display = 'none';
                     storedOrderInfo = null;
+                } else {
+                    // keep previously loaded info until new data arrives
                 }
 
 


### PR DESCRIPTION
## Summary
- preserve previously loaded DB summaries while waiting for new data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883b866dde08326bdac8f4fc8742749