### PR TITLE
Fix Gmail review sidebar clearing on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ All notable changes to this project will be documented in this file.
 - Gmail EMAIL SEARCH now keeps the current email open so the sidebar remains visible until the message is closed.
 - Issue box uploads disable the comment field; each file shows a rename field below its name and the action button reads **UPLOAD** or **CONVERT & UPLOAD** depending on file types.
 - Fixed Gmail Review Mode sidebar disappearing after using EMAIL SEARCH; summaries now remain while the email is open.
+- Fixed Gmail Review Mode SEARCH button clearing the sidebar while waiting for KOUNT or ADYEN data; existing summaries now persist.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1503,7 +1503,11 @@
         async function handleEmailSearchClick(xray = false) {
             if (searchInProgress) return;
             searchInProgress = true;
-            showLoadingState();
+            if (xray || !reviewMode) {
+                showLoadingState();
+            } else {
+                ensureIssueControls(true);
+            }
 
             const context = extractOrderContextFromEmail();
             currentContext = context;


### PR DESCRIPTION
## Summary
- prevent Gmail SEARCH from wiping sidebar details in review mode
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883bc4b3684832680b4a95d4c454d0e