### PR TITLE
Fix file upload label in Gmail Review Mode

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1944,12 +1944,14 @@ sbObj.build(`
         function updateResolveButtonLabel() {
             const btn = document.getElementById('issue-resolve-btn');
             if (!btn) return;
-            if (droppedFiles.length) {
-                btn.textContent = allFilesPdf(droppedFiles) ?
-                    'UPLOAD' : 'CONVERT & UPLOAD';
+            if (reviewMode && droppedFiles.length) {
+                btn.textContent = allFilesPdf(droppedFiles)
+                    ? 'UPLOAD'
+                    : 'CONVERT & UPLOAD';
             } else {
-                btn.textContent = reviewMode ?
-                    'COMMENT & RELEASE' : 'COMMENT & RESOLVE';
+                btn.textContent = reviewMode
+                    ? 'COMMENT & RELEASE'
+                    : 'COMMENT & RESOLVE';
             }
         }
 


### PR DESCRIPTION
## Summary
- update Gmail issues box so action button only displays **CONVERT & UPLOAD** or **UPLOAD** when in Review Mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883bf4ee57c8326bb3418a2d9ed151b