### PR TITLE
Fix INT STORAGE loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@ All notable changes to this project will be documented in this file.
 - Issue box uploads disable the comment field; each file shows a rename field below its name and the action button reads **UPLOAD** or **CONVERT & UPLOAD** depending on file types.
 - Fixed Gmail Review Mode sidebar disappearing after using EMAIL SEARCH; summaries now remain while the email is open.
 - Fixed Gmail Review Mode SEARCH button clearing the sidebar while waiting for KOUNT or ADYEN data; existing summaries now persist.
+- Fixed DB sidebar INT STORAGE box showing "Loading..." indefinitely by opening the storage page in the background and loading the uploaded files.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -20,6 +20,7 @@ class DBLauncher extends Launcher {
     let reinstatementMode = false;
     let miscMode = false;
     let autoFamilyTreeDone = false;
+    let intStorageOpenedFor = null;
     let noStore = new URLSearchParams(location.search).get('fennec_no_store') === '1';
     // Tracks whether Review Mode is active across DB pages
     let reviewMode = false;
@@ -2889,6 +2890,13 @@ function getLastHoldUser() {
     function loadIntStorage(orderId) {
         const box = document.getElementById('int-storage-box');
         if (!box || !orderId) return;
+        if (intStorageOpenedFor !== orderId) {
+            intStorageOpenedFor = orderId;
+            bg.openOrReuseTab({
+                url: `${location.origin}/storage/incfile/${orderId}`,
+                active: false
+            });
+        }
         box.innerHTML = '<div style="text-align:center;color:#aaa">Loading...</div>';
         fetch(`/storage/incfile/${orderId}`, { credentials: 'include' })
             .then(r => r.text())


### PR DESCRIPTION
## Summary
- open the DB storage page in the background when loading INT STORAGE docs
- document the fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883c90a141c8326a671e7dbdb6e827a